### PR TITLE
Center hero heading and remove free assessment CTA

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,9 +62,7 @@
         <p>We build and run tailored security programs so you can stay compliant, close deals, and rest easy.</p>
         <div class="hero-actions">
           <a href="https://outlook.office.com/book/VectariIntroduction@vectari.co/?ismsaljsauthenabled" class="button primary">Talk to a Security Expert</a>
-          <a href="#vector" class="button secondary">Get Your Free Assessment</a>
         </div>
-        <small>No hard pitch. 20‑minute discovery to map risks &amp; quick wins.</small>
       </div>
     </section>
     <!-- VECTOR Assessment section -->

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -223,6 +223,7 @@ a:hover {
   font-weight: 800;
   color: #ffffff;
   margin-bottom: 0.5rem;
+  text-align: center;
 }
 
 .hero h2 {


### PR DESCRIPTION
## Summary
- Center the hero headline for "Cybersecurity" in the landing page
- Drop outdated "Get Your Free Assessment" button and discovery blurb

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b961c5ae4832885013213bedcb24d