### PR TITLE
Restrict card toggle to header to avoid link-like text

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -374,7 +374,6 @@ a:hover {
   padding: 1.25rem;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
   color: #f3f4f6;
-  cursor: pointer;
   position: relative;
 }
 
@@ -382,6 +381,7 @@ a:hover {
   margin-top: 0;
   font-size: 1.2rem;
   color: var(--color-orange);
+  cursor: pointer;
 }
 
 .card p {

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -2,13 +2,16 @@
 // This script enables cards to expand and reveal additional details when clicked.
 
 document.addEventListener('DOMContentLoaded', function () {
-  // Attach click listeners to any card element across all sections.
-  // When a card is clicked, toggle the "active" class to reveal or hide the card-details.
+  // Attach listeners to card headers so only the titles toggle details.
+  // This prevents body text (e.g., framework names) from behaving like links.
   const cards = document.querySelectorAll('.cards .card');
   cards.forEach(function (card) {
-    card.addEventListener('click', function () {
-      card.classList.toggle('active');
-    });
+    const header = card.querySelector('h3');
+    if (header) {
+      header.addEventListener('click', function () {
+        card.classList.toggle('active');
+      });
+    }
   });
 
   // Framework compliance items may also contain hidden details. They use the class


### PR DESCRIPTION
## Summary
- limit card toggling to headers so body text like "NIST 800-171/53" isn't treated as clickable
- move pointer cursor from entire card to header

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_689bb656be6083288981487675fe785a