### PR TITLE
Move hero text closer to top of page

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -212,11 +212,11 @@ a:hover {
 /* Hero section */
 .hero {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
   text-align: center;
   min-height: 80vh;
-  padding: 4rem 1rem;
+  padding: 2rem 1rem;
 }
 
 .hero-content {


### PR DESCRIPTION
## Summary
- Align hero section to flex-start to position text near the top
- Reduce hero padding to shrink vertical spacing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bcf15c0c4832892650ef40da33ae4