### PR TITLE
Add centered video background for VECTOR Assessment

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,36 +65,41 @@
     </section>
     <!-- VECTOR Assessment section -->
       <section id="vector" class="section bg-light">
-        <h2>VECTOR Assessment</h2>
-        <p>Our VECTOR assessment is designed to quickly pinpoint gaps in your organization.</p>
-        <div class="vector-steps">
-          <div class="vector-step">
-            <div class="vector-title"><strong>V</strong>isibility</div>
-            <div class="vector-detail">Visibility across your AI, app, data, and access controls exposes blind spots early.</div>
+        <video class="vector-bg-video" autoplay loop muted playsinline>
+          <source src="backgrounds/target.mp4" type="video/mp4">
+        </video>
+        <div class="vector-content">
+          <h2>VECTOR Assessment</h2>
+          <p>Our VECTOR assessment is designed to quickly pinpoint gaps in your organization.</p>
+          <div class="vector-steps">
+            <div class="vector-step">
+              <div class="vector-title"><strong>V</strong>isibility</div>
+              <div class="vector-detail">Visibility across your AI, app, data, and access controls exposes blind spots early.</div>
+            </div>
+            <div class="vector-step">
+              <div class="vector-title"><strong>E</strong>ngineering</div>
+              <div class="vector-detail">Engineering reviews ensure your architecture and controls are built for resilience from day one.</div>
+            </div>
+            <div class="vector-step">
+              <div class="vector-title"><strong>C</strong>ompliance</div>
+              <div class="vector-detail">Compliance mapping shows how your policies meet industry and regulatory requirements.</div>
+            </div>
+            <div class="vector-step">
+              <div class="vector-title"><strong>T</strong>hreats</div>
+              <div class="vector-detail">Threat analysis highlights likely attack paths and adversaries so you can prepare.</div>
+            </div>
+            <div class="vector-step">
+              <div class="vector-title"><strong>O</strong>rganization</div>
+              <div class="vector-detail">Organizational insight connects leadership, culture, and staffing to security success.</div>
+            </div>
+            <div class="vector-step">
+              <div class="vector-title"><strong>R</strong>isk</div>
+              <div class="vector-detail">Risk scoring helps prioritize remediation based on business impact and likelihood.</div>
+            </div>
           </div>
-          <div class="vector-step">
-            <div class="vector-title"><strong>E</strong>ngineering</div>
-            <div class="vector-detail">Engineering reviews ensure your architecture and controls are built for resilience from day one.</div>
+          <div class="vector-cta">
+            <a href="https://outlook.office.com/book/VectariIntroduction@vectari.co/?ismsaljsauthenabled" class="button primary">Book Free Assessment</a>
           </div>
-          <div class="vector-step">
-            <div class="vector-title"><strong>C</strong>ompliance</div>
-            <div class="vector-detail">Compliance mapping shows how your policies meet industry and regulatory requirements.</div>
-          </div>
-          <div class="vector-step">
-            <div class="vector-title"><strong>T</strong>hreats</div>
-            <div class="vector-detail">Threat analysis highlights likely attack paths and adversaries so you can prepare.</div>
-          </div>
-          <div class="vector-step">
-            <div class="vector-title"><strong>O</strong>rganization</div>
-            <div class="vector-detail">Organizational insight connects leadership, culture, and staffing to security success.</div>
-          </div>
-          <div class="vector-step">
-            <div class="vector-title"><strong>R</strong>isk</div>
-            <div class="vector-detail">Risk scoring helps prioritize remediation based on business impact and likelihood.</div>
-          </div>
-        </div>
-        <div class="vector-cta">
-          <a href="https://outlook.office.com/book/VectariIntroduction@vectari.co/?ismsaljsauthenabled" class="button primary">Book Free Assessment</a>
         </div>
       </section>
     <!-- Services section -->

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -322,6 +322,28 @@ a:hover {
   display: block;
 }
 
+#vector {
+  position: relative;
+  overflow: hidden;
+}
+
+#vector .vector-bg-video {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 400px;
+  max-width: 60%;
+  opacity: 0.15;
+  z-index: 0;
+  pointer-events: none;
+}
+
+#vector .vector-content {
+  position: relative;
+  z-index: 1;
+}
+
 .card {
   background: rgba(255, 255, 255, 0.1);
   border: 1px solid rgba(255, 255, 255, 0.2);


### PR DESCRIPTION
## Summary
- Add new `target.mp4` video as a subtle background in the VECTOR Assessment section
- Center the animation and overlay section content above it
- Add styling to keep the video constrained and non-interactive

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c1abc1ecc83288170ce91a276a092