### PR TITLE
Remove contact form overlay

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -422,10 +422,9 @@ a:hover {
 /* Contact section */
 /* Contact section styles */
 .contact-section {
-  /* Darker backdrop for the entire contact area */
-  /* Darken the overall contact section slightly to contrast with the brighter background. */
-  background: rgba(0, 15, 30, 0.75);
-  border-top: 1px solid rgba(255, 255, 255, 0.15);
+  /* Remove the tinted box effect behind the contact form */
+  background: transparent;
+  border-top: none;
   padding: 4rem 1rem;
 }
 
@@ -439,9 +438,9 @@ a:hover {
  * vertically. The card is tinted dark for contrast and framed with a subtle border.
  */
 .contact-container {
-  background: rgba(0, 16, 32, 0.85);
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  border-radius: 1rem;
+  background: transparent;
+  border: none;
+  border-radius: 0;
   padding: 2rem;
   max-width: 1100px;
   margin: 0 auto;


### PR DESCRIPTION
## Summary
- remove tinted overlay from the contact section and container for a cleaner look

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c1b365cec83289cab029ebb87b8fe