### PR TITLE
Blur VECTOR video edges

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -346,6 +346,8 @@ a:hover {
   height: auto;
   max-width: 120%;
   opacity: 0.4;
+  /* Soften video edges into the surrounding background */
+  box-shadow: 0 0 80px 40px #000 inset;
   z-index: 0;
   pointer-events: none;
 }


### PR DESCRIPTION
## Summary
- Blend the VECTOR assessment background video into the page by darkening its edges with an inset box shadow.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c29cdecf08328830fd3c68e31ffe7