### PR TITLE
Remove gradient background from vector section

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -334,7 +334,7 @@ a:hover {
 #vector {
   position: relative;
   overflow: hidden;
-  background: linear-gradient(to bottom, rgba(0, 118, 209, 0.6) 0%, #000 50%, #000 100%);
+  background-color: #000;
 }
 
 #vector .vector-content {


### PR DESCRIPTION
## Summary
- replace gradient background of VECTOR assessment section with a solid black background

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c338bd1308328bfc8d76a247f810a