### PR TITLE
Slow trust bar animation and add spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@
           --trust-chip-border: #1f2a44;
           --trust-accent: #2a9d8f;
           --trust-gap: 2rem;
-          --trust-speed: 40s;
+          --trust-speed: 80s;
         }
         .trust-bar {
           background: var(--trust-bg);
@@ -104,6 +104,7 @@
           height: 3.5rem;
           display: flex;
           align-items: center;
+          margin-top: 1rem;
         }
         .trust-viewport {
           overflow: hidden;


### PR DESCRIPTION
## Summary
- slow trust bar scrolling by 50%
- add extra space between hero and trust bar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cab9ff9308328addc8533325119c0