### PR TITLE
Use mixed case for trust bar badges

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,16 +67,16 @@
     <section class="trust-bar" aria-label="Trust &amp; assurance">
       <div class="trust-viewport">
         <ul class="trust-track" role="list">
-          <li class="trust-badge" tabindex="0">CISO-Led</li>
-          <li class="trust-badge" tabindex="0">Enterprise Experience</li>
-          <li class="trust-badge" tabindex="0">US-Based</li>
-          <li class="trust-badge" tabindex="0">Vendor-Neutral</li>
-          <li class="trust-badge" tabindex="0">Customer-First</li>
+          <li class="trust-badge" tabindex="0">CISO-led</li>
+          <li class="trust-badge" tabindex="0">Enterprise experience</li>
+          <li class="trust-badge" tabindex="0">US-based</li>
+          <li class="trust-badge" tabindex="0">Vendor-neutral</li>
+          <li class="trust-badge" tabindex="0">Customer-first</li>
           <li class="trust-badge" tabindex="0">Clear SLAs</li>
           <li class="trust-badge" tabindex="0">Responsible AI</li>
-          <li class="trust-badge" tabindex="0">Risk-Driven</li>
-          <li class="trust-badge" tabindex="0">Audit Experience</li>
-          <li class="trust-badge" tabindex="0">MSP Friendly</li>
+          <li class="trust-badge" tabindex="0">Risk-driven</li>
+          <li class="trust-badge" tabindex="0">Audit experience</li>
+          <li class="trust-badge" tabindex="0">MSP friendly</li>
         </ul>
         <ul class="trust-track trust-track--clone" aria-hidden="true"></ul>
       </div>
@@ -124,7 +124,6 @@
           padding: 0.25rem 0.75rem;
           font-size: clamp(0.75rem, 2vw, 0.95rem);
           letter-spacing: 0.05em;
-          text-transform: uppercase;
           white-space: nowrap;
           line-height: 1;
           height: 2rem;


### PR DESCRIPTION
## Summary
- Switch trust-bar badge labels to sentence case for clarity (e.g., "CISO-led", "Clear SLAs").
- Remove CSS rule that forced all-caps text in trust badges.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cf93b892c8328b0c20b315945f6ba