### PR TITLE
Fix Problems section CTA and layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -239,14 +239,14 @@
         </li>
       </ul>
       <div class="cta-row">
-        <a href="#how-we-start" class="cta-primary">See how we start</a>
-        <a href="#contact" class="cta-link">Schedule a 20-min fit call</a>
+        <a href="https://outlook.office.com/book/VectariIntroduction@vectari.co/?ismsaljsauthenabled" class="cta-button">Schedule a Call</a>
+        <span class="cta-note">to see if we can help you.</span>
       </div>
     </section>
     <style>
       /* design tokens and layout - tweak colors/spacing here */
       :root{
-        --bg:#0b0b0b; /* section bg */
+        --bg:#000; /* section bg */
         --fg:#ffffff; /* main text */
         --card:transparent; /* card surface */
         --border:#1f2430; /* fallback border */
@@ -262,10 +262,11 @@
         padding:clamp(1.25rem,3vw,2rem);
         margin:clamp(2rem,6vw,4rem) 0;
         width:100%;
+        overflow-x:hidden;
       }
       #problems h2{font-size:clamp(1.5rem,4vw,2rem);font-weight:600;margin:0;color:var(--orange);}
       #problems>p{color:var(--fg);margin:.25rem 0 var(--gap);} /* change intro copy above */
-      .grid{list-style:none;padding:0;margin:0;display:grid;gap:var(--gap);grid-template-columns:repeat(auto-fit,minmax(220px,1fr));grid-auto-rows:1fr;}
+      .grid{list-style:none;padding:0;margin:0;display:grid;gap:var(--gap);grid-template-columns:repeat(auto-fit,minmax(min(220px,100%),1fr));grid-auto-rows:1fr;}
       .grid li{display:flex;}
       .grid article{
         background:var(--card);
@@ -286,21 +287,15 @@
         -webkit-mask-composite:xor;mask-composite:exclude;pointer-events:none;
       }
       .grid svg{width:32px;height:32px;color:var(--blue);}
-      .grid h3{font-size:clamp(1.1rem,2.5vw,1.25rem);margin:0;font-weight:600;color:var(--orange);}
+      .grid h3{font-size:clamp(1rem,2.3vw,1.2rem);margin:0;font-weight:600;color:var(--orange);}
       .grid p{color:var(--fg);margin:0;}
       .grid article.is-visible{opacity:1;transform:none;}
       .grid article:is(:hover,:focus-visible){
         box-shadow:0 8px 16px -4px rgba(0,0,0,.6),0 0 8px 2px var(--blue);
         transform:translateY(-4px); /* adjust hover lift */
       }
-      .cta-row{display:flex;flex-wrap:wrap;gap:1rem;margin-top:var(--gap);}
-      .cta-primary{
-        background:var(--blue);color:#fff;text-decoration:none;
-        padding:.75rem 1.25rem;border-radius:8px;font-weight:600;display:inline-block;
-      }
-      .cta-primary:focus-visible{outline:2px solid var(--orange);outline-offset:2px;}
-      .cta-link{color:var(--blue);text-decoration:underline;align-self:center;}
-      .cta-link:focus-visible{outline:2px solid var(--orange);outline-offset:2px;}
+      .cta-row{display:flex;flex-wrap:wrap;gap:.5rem;margin-top:var(--gap);justify-content:center;align-items:center;text-align:center;}
+      .cta-note{color:var(--fg);}
       @media(prefers-reduced-motion:reduce){.grid article{transition:none;transform:none;}}
     </style>
     <script>


### PR DESCRIPTION
## Summary
- Match "Problems we solve" background to full black and prevent horizontal overflow
- Replace bottom CTAs with single centered Schedule a Call button plus helper text
- Tweak card grid and heading sizes for smaller screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d11ae20b08328b88d9538d500e6a9