### PR TITLE
fix: prevent horizontal overflow in problems grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -260,13 +260,14 @@
         background:var(--bg);
         color:var(--fg);
         padding:clamp(1.25rem,3vw,2rem);
-        margin:clamp(2rem,6vw,4rem) 0;
-        width:100%;
-        overflow-x:hidden;
+        margin-block:clamp(2rem,6vw,4rem);
+        margin-inline:auto;
+        inline-size:100%;
+        max-inline-size:1200px;
       }
       #problems h2{font-size:clamp(1.5rem,4vw,2rem);font-weight:600;margin:0;color:var(--orange);}
       #problems>p{color:var(--fg);margin:.25rem 0 var(--gap);} /* change intro copy above */
-      .grid{list-style:none;padding:0;margin:0;display:grid;gap:var(--gap);grid-template-columns:repeat(auto-fit,minmax(min(220px,100%),1fr));grid-auto-rows:1fr;}
+      .grid{list-style:none;padding:0;margin:0;display:grid;gap:var(--gap);grid-template-columns:repeat(auto-fit,minmax(min(360px,100%),1fr));grid-auto-rows:1fr;}
       .grid li{display:flex;}
       .grid article{
         background:var(--card);

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -21,6 +21,9 @@
 }
 
 /* Reset and base styles */
+*,*::before,*::after {
+  box-sizing: border-box;
+}
 html, body {
   margin: 0;
   padding: 0;
@@ -28,6 +31,8 @@ html, body {
   color: var(--color-navy);
   /* Use a solid black background for now. */
   background: #000;
+  overflow-x: hidden;
+  overflow-x: clip;
 }
 
 /* Fluid type scale for better readability on all screens */


### PR DESCRIPTION
## Summary
- constrain `#problems` grid to wrap cleanly and cap width so cards aren't cut off
- apply global border-box sizing and clip horizontal overflow on `html, body`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d1495a7408328837f9e34e6519bc1