### PR TITLE
fix problems layout for large screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -263,18 +263,12 @@
         margin-inline:auto;
         padding-block:clamp(1.25rem,3vw,2rem);
         padding-inline:clamp(1rem,5vw,2.5rem);
-        inline-size:90%;
-        max-inline-size:1400px;
+        inline-size:100%;
+        max-inline-size:1600px;
       }
       #problems h2{font-size:clamp(1.5rem,4vw,2rem);font-weight:600;margin:0;color:var(--orange);}
       #problems>p{color:var(--fg);margin:.25rem 0 var(--gap);} /* change intro copy above */
-      .grid{list-style:none;padding:0;margin:0;display:grid;gap:var(--gap);grid-template-columns:1fr;grid-auto-rows:1fr;}
-      @media(min-width:768px){
-        .grid{grid-template-columns:repeat(3,1fr);}
-      }
-      @media(min-width:1200px){
-        .grid{grid-template-columns:repeat(2,1fr);}
-      }
+      .grid{list-style:none;padding:0;margin:0;display:grid;gap:var(--gap);grid-auto-rows:1fr;}
       .grid li{display:flex;}
       .grid article{
         background:var(--card);
@@ -287,7 +281,7 @@
         transition:opacity .6s,transform .6s,box-shadow .3s;
         outline:0;
         flex:1;
-        min-inline-size:250px;
+        min-inline-size:220px;
       }
       .grid article::before{
         content:"";position:absolute;inset:0;padding:1px;border-radius:inherit;

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -300,9 +300,21 @@ a:hover {
   padding: 0;
   margin: 2rem 0 0;
   display: grid;
-  gap: 1.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--gap, 1.5rem);
+  grid-template-columns: 1fr;
   grid-auto-rows: 1fr;
+}
+
+@media (min-width: 768px) {
+  #problems ul {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (min-width: 1600px) {
+  #problems ul {
+    grid-template-columns: repeat(6, 1fr);
+  }
 }
 
 #problems li {


### PR DESCRIPTION
## Summary
- allow the Problems section to grow wider and fit six cards across
- define responsive grid columns: single column on mobile, three columns on tablets, six on wide screens
- reduce card minimum width for better fit

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d240faa788328b551a04efa85b6a9