### PR TITLE
Add accessible “What we do” section

### DIFF
--- a/index.html
+++ b/index.html
@@ -312,6 +312,195 @@
         cards.forEach(card=>observer.observe(card));
       });
     </script>
+    <!-- What we do section -->
+    <section id="what-we-do" aria-label="What we do">
+      <div class="container">
+        <h2>What we do</h2>
+        <div class="tabs" role="tablist" aria-label="Services">
+          <button id="tab-leadership" role="tab" aria-controls="panel-leadership" aria-selected="true">Security Leadership</button>
+          <button id="tab-operations" role="tab" aria-controls="panel-operations" tabindex="-1">Security Operations</button>
+          <button id="tab-audit" role="tab" aria-controls="panel-audit" tabindex="-1">Audit Readiness</button>
+          <button id="tab-incident" role="tab" aria-controls="panel-incident" tabindex="-1">Incident Preparedness</button>
+          <button id="tab-ai" role="tab" aria-controls="panel-ai" tabindex="-1">AI Governance</button>
+        </div>
+        <div id="panel-leadership" role="tabpanel" aria-labelledby="tab-leadership">
+          <div class="panel-content">
+            <div class="left">
+              <p class="promise">Strategic leadership and an operating team—no hires required.</p>
+              <ul class="outcomes">
+                <li>Risk-led roadmap &amp; 90-day plan</li>
+                <li>Quarterly board-ready briefings</li>
+                <li>One accountable owner</li>
+              </ul>
+            </div>
+            <ul class="facts" role="list">
+              <li>≈20 years experience</li>
+              <li>Multi-industry (SaaS, RIA/Finance, CPA)</li>
+              <li>US-based &amp; background-checked</li>
+              <li>Board-ready communication</li>
+              <li>Audit readiness (SOC 2 / FTC / SEC S-P)</li>
+              <li>Incident leadership &amp; tabletop drills</li>
+              <li>Vendor-neutral; MSP-friendly</li>
+              <li>Risk-led policies &amp; governance</li>
+            </ul>
+          </div>
+          <a class="see-start" href="#how">See how we start</a>
+        </div>
+        <div id="panel-operations" role="tabpanel" aria-labelledby="tab-operations" hidden>
+          <div class="panel-content">
+            <div class="left">
+              <p class="promise">We run the recurring security work—and keep evidence ready.</p>
+              <ul class="outcomes">
+                <li>Access &amp; vendor reviews on schedule</li>
+                <li>Monitoring baseline, alert handling, SLAs</li>
+                <li>Trust Center: customer-ready artifacts</li>
+              </ul>
+            </div>
+            <ul class="facts" role="list">
+              <li>Access reviews on schedule</li>
+              <li>Vendor reviews on schedule</li>
+              <li>EDR + M365 monitoring</li>
+              <li>Alert triage SLAs</li>
+              <li>Evidence pipeline (Trust Center)</li>
+              <li>MSP coordination</li>
+              <li>KPI reporting</li>
+            </ul>
+          </div>
+          <a class="see-start" href="#how">See how we start</a>
+        </div>
+        <div id="panel-audit" role="tabpanel" aria-labelledby="tab-audit" hidden>
+          <div class="panel-content">
+            <div class="left">
+              <p class="promise">Be ready for SOC 2 / FTC / SEC S-P and customer questionnaires.</p>
+              <ul class="outcomes">
+                <li>Controls mapped to relevant frameworks</li>
+                <li>Policies &amp; artifacts organized and shareable</li>
+                <li>Auditor coordination &amp; pre-audit checks</li>
+              </ul>
+            </div>
+            <ul class="facts" role="list">
+              <li>SOC 2 / FTC / SEC S-P</li>
+              <li>Questionnaire support</li>
+              <li>Artifact packs organized</li>
+              <li>Pre-audit checks</li>
+              <li>Policy set maintained</li>
+              <li>Evidence on hand</li>
+              <li>Auditor-friendly cadence</li>
+            </ul>
+          </div>
+          <a class="see-start" href="#how">See how we start</a>
+        </div>
+        <div id="panel-incident" role="tabpanel" aria-labelledby="tab-incident" hidden>
+          <div class="panel-content">
+            <div class="left">
+              <p class="promise">Plan, on-call leadership, and faster, calmer response.</p>
+              <ul class="outcomes">
+                <li>IR plan &amp; playbooks (roles, comms, legal)</li>
+                <li>Tabletop drills and after-action reports</li>
+                <li>Recovery guidance and executive updates</li>
+              </ul>
+            </div>
+            <ul class="facts" role="list">
+              <li>On-call leadership</li>
+              <li>Tabletop drills</li>
+              <li>Comms workflow</li>
+              <li>Legal coordination</li>
+              <li>Forensics/vendor coordination</li>
+              <li>After-action reports</li>
+              <li>Executive updates</li>
+            </ul>
+          </div>
+          <a class="see-start" href="#how">See how we start</a>
+        </div>
+        <div id="panel-ai" role="tabpanel" aria-labelledby="tab-ai" hidden>
+          <div class="panel-content">
+            <div class="left">
+              <p class="promise">Practical policies, risk controls, and usage guardrails.</p>
+              <ul class="outcomes">
+                <li>Acceptable-use policy for gen-AI &amp; copilots</li>
+                <li>Model &amp; data risk checks (PII, IP, vendors)</li>
+                <li>Training &amp; review cadence with approvals</li>
+              </ul>
+            </div>
+            <ul class="facts" role="list">
+              <li>Acceptable Use Policy</li>
+              <li>Data classification / PII</li>
+              <li>Model &amp; vendor risk</li>
+              <li>M365 Copilot guardrails</li>
+              <li>Training &amp; approvals</li>
+              <li>Review cadence</li>
+              <li>Usage logging</li>
+              <li>Accessibility &amp; behavior</li>
+            </ul>
+          </div>
+          <a class="see-start" href="#how">See how we start</a>
+        </div>
+      </div>
+    </section>
+    <style>
+      #what-we-do{
+        --bg:#0b0b0b;
+        --fg:#e5e7eb;
+        --muted:#9aa3b2;
+        --card:#111318;
+        --border:#1f2430;
+        --navy:#0b132b;
+        --teal:#2a9d8f;
+        --orange:#f4a261;
+        --radius:16px;
+        --container:1120px;
+        background:var(--bg);
+        color:var(--fg);
+      }
+      #what-we-do .container{max-inline-size:var(--container);margin-inline:auto;padding:clamp(16px,4vw,32px);}
+      #what-we-do h2{font-size:clamp(1.5rem,4vw,2rem);font-weight:600;margin:0 0 1rem;color:var(--orange);}
+      #what-we-do .tabs{display:flex;flex-wrap:wrap;gap:.5rem;list-style:none;margin:0 0 1rem;padding:0;}
+      #what-we-do [role="tab"]{border:1px solid var(--border);background:transparent;border-radius:9999px;padding:.5rem 1rem;color:var(--fg);cursor:pointer;font:inherit;}
+      #what-we-do [role="tab"][aria-selected="true"]{background:var(--teal);color:var(--bg);}
+      #what-we-do [role="tab"]:focus-visible{outline:2px solid var(--orange);outline-offset:2px;}
+      #what-we-do [role="tabpanel"]{background:var(--card);border-radius:var(--radius);outline:1px solid var(--border);padding:clamp(16px,4vw,32px);margin-top:1rem;}
+      #what-we-do .panel-content{display:flex;flex-direction:column;gap:1.5rem;}
+      #what-we-do .left{flex:1;display:flex;flex-direction:column;gap:1rem;}
+      #what-we-do .outcomes{margin:0;padding-left:1.25rem;display:flex;flex-direction:column;gap:.5rem;color:var(--fg);}
+      #what-we-do .facts{margin:0;padding:0;list-style:none;display:flex;flex-direction:column;gap:.5rem;}
+      #what-we-do .facts li{border:1px solid var(--border);border-radius:9999px;padding:.25rem .75rem;background:var(--navy);align-self:flex-start;}
+      #what-we-do .see-start{display:inline-block;margin-top:1rem;font-size:.875rem;color:var(--teal);text-decoration:underline;}
+      #what-we-do .see-start:focus-visible{outline:2px solid var(--orange);outline-offset:2px;}
+      @media(min-width:900px){#what-we-do .panel-content{flex-direction:row;}}
+      @media(prefers-reduced-motion:reduce){#what-we-do [role="tab"],#what-we-do [role="tabpanel"]{transition:none;}}
+    </style>
+    <script>
+      document.addEventListener('DOMContentLoaded',()=>{
+        const section=document.getElementById('what-we-do');
+        const tabs=section.querySelectorAll('[role="tab"]');
+        const panels=section.querySelectorAll('[role="tabpanel"]');
+        function activate(tab){
+          tabs.forEach(t=>{
+            const selected=t===tab;
+            t.setAttribute('aria-selected',selected);
+            if(selected){t.removeAttribute('tabindex');}else{t.setAttribute('tabindex','-1');}
+          });
+          panels.forEach(p=>{p.hidden=p.id!==tab.getAttribute('aria-controls');});
+        }
+        tabs.forEach((tab)=>{
+          tab.addEventListener('click',()=>activate(tab));
+          tab.addEventListener('keydown',e=>{
+            const idx=[...tabs].indexOf(tab);
+            if(e.key==='ArrowRight'||e.key==='ArrowLeft'){
+              e.preventDefault();
+              const dir=e.key==='ArrowRight'?1:-1;
+              const next=(idx+dir+tabs.length)%tabs.length;
+              tabs[next].focus();
+            }
+            if(e.key==='Enter'||e.key===' '){
+              e.preventDefault();
+              activate(tab);
+            }
+          });
+        });
+        activate(tabs[0]);
+      });
+    </script>
     <!-- VECTOR Assessment section -->
       <section id="vector" class="section">
         <div class="vector-content">


### PR DESCRIPTION
## Summary
- add responsive, tabbed "What we do" section with five service panels
- include scoped design tokens, pill facts, and #how CTA
- implement keyboard-accessible tabs and panel toggling

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_689d7b490d1c832894ed4e389c39eda4