### PR TITLE
Refine security leadership messaging

### DIFF
--- a/index.html
+++ b/index.html
@@ -326,11 +326,17 @@
         <div id="panel-leadership" role="tabpanel" aria-labelledby="tab-leadership">
           <div class="panel-content">
             <div class="left">
-              <p class="promise">Strategic leadership and an operating team—no hires required.</p>
+              <p class="promise">What our security leaders handle in your organization:</p>
               <ul class="outcomes">
-                <li>Risk-led roadmap &amp; 90-day plan</li>
-                <li>Quarterly board-ready briefings</li>
-                <li>One accountable owner</li>
+                <li>Build and own a 90-day plan and risk-led roadmap</li>
+                <li>Translate risk into business terms; board-ready KPIs and briefings</li>
+                <li>Set guardrails and provide independent oversight of MSP/IT (separation of duties)</li>
+                <li>Establish policies &amp; standards people will actually use; light training</li>
+                <li>Put access &amp; vendor reviews on a schedule—and make them stick</li>
+                <li>Stand up a Trust Center with artifacts for audits &amp; questionnaires</li>
+                <li>Lead incident preparedness (IR plan, roles, drills, on-call leadership)</li>
+                <li>Align identity &amp; device strategy (SSO/M365, EDR) with least privilege</li>
+                <li>Answer customer security questionnaires and coordinate with auditors</li>
               </ul>
             </div>
             <ul class="facts" role="list">


### PR DESCRIPTION
## Summary
- Emphasize leadership responsibilities in the Security Leadership section
- Replace existing outcomes with expanded list of nine services

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d7f618d708328a75fba82c27ec95b