### PR TITLE
Add labels to chips in What we do section

### DIFF
--- a/index.html
+++ b/index.html
@@ -339,16 +339,19 @@
                 <li>Answer customer security questionnaires and coordinate with auditors</li>
               </ul>
             </div>
-            <ul class="facts" role="list">
-              <li>≈20 years experience</li>
-              <li>Multi-industry (SaaS, RIA/Finance, CPA)</li>
-              <li>US-based &amp; background-checked</li>
-              <li>Board-ready communication</li>
-              <li>Audit readiness (SOC 2 / FTC / SEC S-P)</li>
-              <li>Incident leadership &amp; tabletop drills</li>
-              <li>Vendor-neutral; MSP-friendly</li>
-              <li>Risk-led policies &amp; governance</li>
-            </ul>
+            <div class="chips">
+              <p class="facts-label">Leader qualifications</p>
+              <ul class="facts" role="list">
+                <li>≈20 years experience</li>
+                <li>Multi-industry (SaaS, RIA/Finance, CPA)</li>
+                <li>US-based &amp; background-checked</li>
+                <li>Board-ready communication</li>
+                <li>Audit readiness (SOC 2 / FTC / SEC S-P)</li>
+                <li>Incident leadership &amp; tabletop drills</li>
+                <li>Vendor-neutral; MSP-friendly</li>
+                <li>Risk-led policies &amp; governance</li>
+              </ul>
+            </div>
           </div>
           <a class="see-start" href="#how">See how we start</a>
         </div>
@@ -362,15 +365,18 @@
                 <li>Trust Center: customer-ready artifacts</li>
               </ul>
             </div>
-            <ul class="facts" role="list">
-              <li>Access reviews on schedule</li>
-              <li>Vendor reviews on schedule</li>
-              <li>EDR + M365 monitoring</li>
-              <li>Alert triage SLAs</li>
-              <li>Evidence pipeline (Trust Center)</li>
-              <li>MSP coordination</li>
-              <li>KPI reporting</li>
-            </ul>
+            <div class="chips">
+              <p class="facts-label">Operational commitments</p>
+              <ul class="facts" role="list">
+                <li>Access reviews on schedule</li>
+                <li>Vendor reviews on schedule</li>
+                <li>EDR + M365 monitoring</li>
+                <li>Alert triage SLAs</li>
+                <li>Evidence pipeline (Trust Center)</li>
+                <li>MSP coordination</li>
+                <li>KPI reporting</li>
+              </ul>
+            </div>
           </div>
           <a class="see-start" href="#how">See how we start</a>
         </div>
@@ -384,15 +390,18 @@
                 <li>Auditor coordination &amp; pre-audit checks</li>
               </ul>
             </div>
-            <ul class="facts" role="list">
-              <li>SOC 2 / FTC / SEC S-P</li>
-              <li>Questionnaire support</li>
-              <li>Artifact packs organized</li>
-              <li>Pre-audit checks</li>
-              <li>Policy set maintained</li>
-              <li>Evidence on hand</li>
-              <li>Auditor-friendly cadence</li>
-            </ul>
+            <div class="chips">
+              <p class="facts-label">Readiness scope</p>
+              <ul class="facts" role="list">
+                <li>SOC 2 / FTC / SEC S-P</li>
+                <li>Questionnaire support</li>
+                <li>Artifact packs organized</li>
+                <li>Pre-audit checks</li>
+                <li>Policy set maintained</li>
+                <li>Evidence on hand</li>
+                <li>Auditor-friendly cadence</li>
+              </ul>
+            </div>
           </div>
           <a class="see-start" href="#how">See how we start</a>
         </div>
@@ -406,15 +415,18 @@
                 <li>Recovery guidance and executive updates</li>
               </ul>
             </div>
-            <ul class="facts" role="list">
-              <li>On-call leadership</li>
-              <li>Tabletop drills</li>
-              <li>Comms workflow</li>
-              <li>Legal coordination</li>
-              <li>Forensics/vendor coordination</li>
-              <li>After-action reports</li>
-              <li>Executive updates</li>
-            </ul>
+            <div class="chips">
+              <p class="facts-label">Preparedness components</p>
+              <ul class="facts" role="list">
+                <li>On-call leadership</li>
+                <li>Tabletop drills</li>
+                <li>Comms workflow</li>
+                <li>Legal coordination</li>
+                <li>Forensics/vendor coordination</li>
+                <li>After-action reports</li>
+                <li>Executive updates</li>
+              </ul>
+            </div>
           </div>
           <a class="see-start" href="#how">See how we start</a>
         </div>
@@ -428,16 +440,19 @@
                 <li>Training &amp; review cadence with approvals</li>
               </ul>
             </div>
-            <ul class="facts" role="list">
-              <li>Acceptable Use Policy</li>
-              <li>Data classification / PII</li>
-              <li>Model &amp; vendor risk</li>
-              <li>M365 Copilot guardrails</li>
-              <li>Training &amp; approvals</li>
-              <li>Review cadence</li>
-              <li>Usage logging</li>
-              <li>Accessibility &amp; behavior</li>
-            </ul>
+            <div class="chips">
+              <p class="facts-label">AI guardrails</p>
+              <ul class="facts" role="list">
+                <li>Acceptable Use Policy</li>
+                <li>Data classification / PII</li>
+                <li>Model &amp; vendor risk</li>
+                <li>M365 Copilot guardrails</li>
+                <li>Training &amp; approvals</li>
+                <li>Review cadence</li>
+                <li>Usage logging</li>
+                <li>Accessibility &amp; behavior</li>
+              </ul>
+            </div>
           </div>
           <a class="see-start" href="#how">See how we start</a>
         </div>
@@ -468,6 +483,8 @@
       #what-we-do .panel-content{display:flex;flex-direction:column;gap:1.5rem;}
       #what-we-do .left{flex:1;display:flex;flex-direction:column;gap:1rem;}
       #what-we-do .outcomes{margin:0;padding-left:1.25rem;display:flex;flex-direction:column;gap:.5rem;color:var(--fg);}
+      #what-we-do .chips{display:flex;flex-direction:column;gap:.5rem;}
+      #what-we-do .facts-label{margin:0;color:var(--muted);font-size:.875rem;}
       #what-we-do .facts{margin:0;padding:0;list-style:none;display:flex;flex-direction:column;gap:.5rem;}
       #what-we-do .facts li{border:1px solid var(--border);border-radius:9999px;padding:.25rem .75rem;background:var(--navy);align-self:flex-start;}
       #what-we-do .see-start{display:inline-block;margin-top:1rem;font-size:.875rem;color:var(--teal);text-decoration:underline;}


### PR DESCRIPTION
## Summary
- add descriptive headings above chip lists for each tab in the What we do section
- group chip labels and lists into containers and add styles for consistent layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d80f459c483289e9e1879b5c4c876