### PR TITLE
Update security leadership tab content and styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -328,15 +328,15 @@
             <div class="left">
               <p class="promise">What our security leaders handle in your organization:</p>
               <ul class="outcomes">
-                <li>Build and own a 90-day plan and risk-led roadmap</li>
-                <li>Translate risk into business terms; board-ready KPIs and briefings</li>
-                <li>Set guardrails and provide independent oversight of MSP/IT (separation of duties)</li>
-                <li>Establish policies &amp; standards people will actually use; light training</li>
-                <li>Put access &amp; vendor reviews on a schedule—and make them stick</li>
-                <li>Stand up a Trust Center with artifacts for audits &amp; questionnaires</li>
-                <li>Lead incident preparedness (IR plan, roles, drills, on-call leadership)</li>
-                <li>Align identity &amp; device strategy (SSO/M365, EDR) with least privilege</li>
-                <li>Answer customer security questionnaires and coordinate with auditors</li>
+                <li><strong>90-day plan</strong> — risk-led roadmap you can defend</li>
+                <li><strong>Board-ready KPIs</strong> — briefings in plain English</li>
+                <li><strong>MSP guardrails</strong> — independent oversight &amp; separation of duties</li>
+                <li><strong>Usable policies</strong> — standards + light training that stick</li>
+                <li><strong>Scheduled reviews</strong> — access &amp; vendors on cadence</li>
+                <li><strong>Trust Center</strong> — artifacts ready for audits &amp; questionnaires</li>
+                <li><strong>IR readiness</strong> — plan, roles, drills, on-call leadership</li>
+                <li><strong>Identity &amp; devices</strong> — SSO/M365 &amp; EDR aligned to least-privilege</li>
+                <li><strong>Customer questionnaires</strong> — handled; auditor coordination</li>
               </ul>
             </div>
             <div class="chips">
@@ -485,7 +485,11 @@
       #what-we-do .facts{margin:0;padding:0;list-style:none;display:flex;flex-direction:column;gap:.5rem;}
       #what-we-do .facts li{border:1px solid var(--border);border-radius:9999px;padding:.25rem .75rem;background:var(--navy);align-self:flex-start;}
       #what-we-do .cta-wrapper{margin-top:2rem;}
-      @media(min-width:900px){#what-we-do .panel-content{flex-direction:row;}}
+      @media(min-width:900px){
+        #what-we-do .panel-content{flex-direction:row;}
+        #what-we-do .panel-content .left{padding-right:1.5rem;border-right:1px solid var(--border);}
+        #what-we-do .panel-content .chips{padding-left:1.5rem;}
+      }
       @media(prefers-reduced-motion:reduce){#what-we-do [role="tab"],#what-we-do [role="tabpanel"]{transition:none;}}
     </style>
     <script>


### PR DESCRIPTION
## Summary
- Refresh security leadership tab bullet points with bolded headings and concise descriptions
- Add vertical divider between tab content columns on large screens

## Testing
- `npm test` *(fails: enoent, could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d876afee08328a7b8e9eb655ee90d