### PR TITLE
Remove unused sections from landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,6 @@
           <img src="static/assets/logo-bar.png" alt="Vectari logo" class="logo-full">
         </div>
         <nav class="nav-links">
-          <a href="#industries">Industries</a>
           <a href="#frameworks">Frameworks</a>
         </nav>
         <a href="https://outlook.office.com/book/VectariIntroduction@vectari.co/?ismsaljsauthenabled" class="cta-button">Schedule a Call</a>
@@ -534,55 +533,6 @@
         activate(tabs[0]);
       });
     </script>
-    <!-- Industries section -->
-    <section id="industries" class="section bg-light">
-      <h2>Industries We Secure</h2>
-      <p>Financial services, healthcare, legal, education, Gov/contractors, SaaS, and high‑growth startups. We learn your business and meet you where you are.</p>
-      <div class="cards three">
-        <div class="card">
-          <h3>Banking &amp; Finance</h3>
-          <p>Outcome‑oriented projects, clear roadmaps, measurable risk reduction.</p>
-          <div class="card-details">
-            <p>We help financial institutions navigate regulatory requirements, fraud prevention, and secure digital transformation. (replace)</p>
-          </div>
-        </div>
-        <div class="card">
-          <h3>Healthcare</h3>
-          <p>Outcome‑oriented projects, clear roadmaps, measurable risk reduction.</p>
-          <div class="card-details">
-            <p>Secure patient data, maintain HIPAA compliance, and protect critical systems with our tailored healthcare services. (replace)</p>
-          </div>
-        </div>
-        <div class="card">
-          <h3>Government &amp; Contractors</h3>
-          <p>Outcome‑oriented projects, clear roadmaps, measurable risk reduction.</p>
-          <div class="card-details">
-            <p>We assist government entities and contractors in meeting NIST, CMMC, and other federal compliance standards while reducing risk. (replace)</p>
-          </div>
-        </div>
-        <div class="card">
-          <h3>Education &amp; Research</h3>
-          <p>Outcome‑oriented projects, clear roadmaps, measurable risk reduction.</p>
-          <div class="card-details">
-            <p>Protect intellectual property, secure research networks, and comply with FERPA and other education‑specific regulations. (replace)</p>
-          </div>
-        </div>
-        <div class="card">
-          <h3>Legal</h3>
-          <p>Outcome‑oriented projects, clear roadmaps, measurable risk reduction.</p>
-          <div class="card-details">
-            <p>Law firms and legal teams benefit from secure client communication, e‑discovery protection, and compliance with professional obligations. (replace)</p>
-          </div>
-        </div>
-        <div class="card">
-          <h3>SaaS &amp; Tech</h3>
-          <p>Outcome‑oriented projects, clear roadmaps, measurable risk reduction.</p>
-          <div class="card-details">
-            <p>Startups and technology companies can scale securely with our expertise in cloud environments, SDLC, and AI security. (replace)</p>
-          </div>
-        </div>
-      </div>
-    </section>
     <!-- Frameworks section -->
     
 <section id="frameworks-carousel" class="section">
@@ -598,32 +548,6 @@
 </section>
 <!-- end frameworks-carousel -->
 
-    <!-- Why Vectari section -->
-    <section id="why" class="section bg-light">
-      <h2>Why Vectari</h2>
-      <div class="cards four">
-        <div class="card">
-          <h3>Vendor‑agnostic</h3>
-          <p>No resell pressure. We pick what fits your environment and budget.</p>
-          <div class="card-details"><p>We remain neutral when recommending solutions, ensuring that your needs—not vendor quotas—drive our technology choices. (replace)</p></div>
-        </div>
-        <div class="card">
-          <h3>Flexible models</h3>
-          <p>Fractional CISO, retainers, and fixed‑scope projects that scale.</p>
-          <div class="card-details"><p>Choose from engagement models that suit your growth—from ad‑hoc projects to fully managed programs—with the ability to adjust as your business evolves. (replace)</p></div>
-        </div>
-        <div class="card">
-          <h3>Hands‑on help</h3>
-          <p>We work side‑by‑side with your team to implement and mature controls.</p>
-          <div class="card-details"><p>Our consultants embed with your team, providing real‑world guidance and implementation support rather than just handing over a report. (replace)</p></div>
-        </div>
-        <div class="card">
-          <h3>Audit‑ready always</h3>
-          <p>Evidence workflows and continuous improvement make audits boring.</p>
-          <div class="card-details"><p>Stay continuously audit‑ready with our evidence management workflows, reducing last‑minute scrambling and ensuring peace of mind. (replace)</p></div>
-        </div>
-      </div>
-    </section>
     <!-- Testimonials section -->
     <section class="section testimonial">
       <h2>Testimonial</h2>


### PR DESCRIPTION
## Summary
- drop "Industries We Secure" section and navigation entry
- remove "Why Vectari" section to streamline page

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d8e0eb55c8328a4c85308fd3c9ef8