### PR TITLE
Expand Compliance & Frameworks carousel width

### DIFF
--- a/static/css/frameworks-carousel.css
+++ b/static/css/frameworks-carousel.css
@@ -11,10 +11,21 @@
   --fw-accent: #ff6d3a;
 }
 #frameworks{ display:none; }
-section#frameworks-carousel{ position: relative; padding: 28px 0 6px; }
-section#frameworks-carousel .section-head{ margin: 0 0 8px 0; padding: 0 12px; }
-section#frameworks-carousel .section-head h2{ font-size: 2rem; margin:0 0 6px 0; }
-section#frameworks-carousel .section-head p{ margin: 0; color:#a9c0cf; max-width: 920px; }
+section#frameworks-carousel{
+  position: relative;
+  padding: 4rem 0;
+  text-align: center;
+}
+section#frameworks-carousel .section-head{
+  margin: 0 0 8px 0;
+  padding: 0;
+}
+section#frameworks-carousel .section-head h2{
+  font-size: 2rem;
+  margin: 0 0 6px 0;
+  color: var(--color-orange);
+}
+section#frameworks-carousel .section-head p{ margin: 0 auto; color:#a9c0cf; max-width: 920px; }
 
 .carousel{
   position: relative; overflow: hidden; padding: 6px 0 10px;

--- a/static/css/fw-constrain.css
+++ b/static/css/fw-constrain.css
@@ -1,6 +1,10 @@
 
 /* FW constrain overrides */
-.fw-bound { max-width: min(1200px, 92vw); margin-inline: auto; padding-inline: 16px; }
+.fw-bound {
+  width: 100%;
+  margin: 0;
+  padding-inline: 16px;
+}
 
 /* Keep headings and carousel inside same width */
 .fw-bound > .section-head,


### PR DESCRIPTION
## Summary
- Stretch Compliance & Frameworks carousel to full-width and center its heading to match the Problems We Solve section
- Keep carousel functionality intact while updating heading color to site accent

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d8f384770832885a8530a6003f000