### PR TITLE
Add section dividers after problem and service sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -309,6 +309,7 @@
         cards.forEach(card=>observer.observe(card));
       });
     </script>
+    <hr class="section-divider">
     <!-- What we do section -->
     <section id="what-we-do" aria-label="What we do">
       <div class="container">
@@ -539,8 +540,9 @@
         activate(tabs[0]);
       });
     </script>
+    <hr class="section-divider">
     <!-- Frameworks section -->
-    
+
 <section id="frameworks-carousel" class="section">
   <div class="fw-bound">
   <div class="section-head">

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -264,6 +264,12 @@ a:hover {
   border-bottom: 1px solid rgba(255, 255, 255, 0.1);
 }
 
+.section-divider {
+  border: 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  margin: 0;
+}
+
 .section h2 {
   font-size: 2rem;
   margin-bottom: 1rem;


### PR DESCRIPTION
## Summary
- insert visual divider after the "Problems we solve" section
- insert same divider after the "What we do" section
- add reusable `.section-divider` style

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d913ad8cc83289b636f7cebf2be79