### PR TITLE
Offset nav anchors for services and challenges sections

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -298,6 +298,12 @@ a:hover {
   margin: 0 auto;
 }
 
+/* Offset anchored sections to account for sticky navbar height */
+#services,
+#challenges {
+  scroll-margin-top: 5rem;
+}
+
 .section.bg-light {
   background: rgba(255, 255, 255, 0.1);
   border-top: 1px solid rgba(255, 255, 255, 0.1);


### PR DESCRIPTION
## Summary
- prevent sticky navbar from overscrolling Services and Challenges sections

## Testing
- `npm test` *(fails: no package.json found)*

------
https://chatgpt.com/codex/tasks/task_e_689d945831a48328a1f763a09a0585c1