### PR TITLE
Adjust mini assessment results layout for clarity

### DIFF
--- a/mini-assessment/app.js
+++ b/mini-assessment/app.js
@@ -397,7 +397,19 @@
       list.forEach((g) => {
         const li = document.createElement("li");
         li.className = "gap-item";
-        li.textContent = `${g.q} – ${g.a}: ${g.risk || ""}`;
+        const text = document.createElement("div");
+        text.className = "gap-text";
+        const qEl = document.createElement("p");
+        qEl.className = "gap-question";
+        qEl.textContent = g.q;
+        const aEl = document.createElement("p");
+        aEl.className = "gap-answer";
+        aEl.textContent = `Your answer: ${g.a}`;
+        const rEl = document.createElement("p");
+        rEl.className = "gap-explanation";
+        rEl.textContent = `Why it's not optimal: ${g.risk || ""}`;
+        text.append(qEl, aEl, rEl);
+        li.appendChild(text);
         ul.appendChild(li);
       });
       group.appendChild(ul);

--- a/mini-assessment/index.html
+++ b/mini-assessment/index.html
@@ -196,7 +196,7 @@
       .results-content {
         display: grid;
         grid-template-columns: 1fr;
-        justify-items: center;
+        justify-items: stretch;
         align-items: flex-start;
         gap: 20px;
         margin-top: 20px;
@@ -227,6 +227,7 @@
         align-items: center;
         justify-content: center;
         gap: 8px;
+        justify-self: center;
       }
       .severity-donut {
         width: var(--donut-size);
@@ -243,9 +244,9 @@
         padding: 0;
         margin: 0;
         display: flex;
-        flex-wrap: wrap;
-        justify-content: center;
-        gap: 8px;
+        flex-direction: column;
+        align-items: center;
+        gap: 4px;
         font-size: 0.75rem;
       }
       .severity-legend li {
@@ -338,6 +339,20 @@
         opacity: 0;
         transition: opacity 0.4s ease-in;
       }
+      .gap-text p {
+        margin: 0;
+      }
+      .gap-text p + p {
+        margin-top: 4px;
+      }
+      .gap-question {
+        font-weight: 600;
+      }
+      .gap-answer,
+      .gap-explanation {
+        color: var(--muted);
+        font-size: 0.875rem;
+      }
       .gap-item::before {
         content: "";
         width: 6px;
@@ -372,6 +387,14 @@
       }
       .severity-2 .gap-item::before {
         background: var(--color-risk-low);
+      }
+      #gaps-title,
+      #gaps,
+      #cta {
+        grid-column: 1 / -1;
+      }
+      #cta {
+        justify-self: center;
       }
       .cta-button {
         display: inline-block;
@@ -468,15 +491,15 @@
             </div>
             <h3 id="result-headline" class="fade-line"></h3>
             <p id="result-message" class="fade-line"></p>
-            <h4 id="gaps-title" class="fade-line" hidden></h4>
-            <div id="gaps" class="gaps fade-line" hidden></div>
-            <a
-              id="cta"
-              class="cta-button fade-line"
-              target="_blank"
-              rel="noopener"
-            ></a>
           </div>
+          <h4 id="gaps-title" class="fade-line" hidden></h4>
+          <div id="gaps" class="gaps fade-line" hidden></div>
+          <a
+            id="cta"
+            class="cta-button fade-line"
+            target="_blank"
+            rel="noopener"
+          ></a>
         </div>
         <button id="restart" type="button" class="fade-line"></button>
       </section>


### PR DESCRIPTION
## Summary
- Stack donut legend vertically for better readability
- Expand “opportunities for improvement” to a full-width single column
- Show question, chosen answer, and explanation on separate lines in improvement list

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a605ca78b48328bb4be000d37cf92a