### PR TITLE
Link mini-assessment logo to vectari.co

### DIFF
--- a/mini-assessment/index.html
+++ b/mini-assessment/index.html
@@ -441,7 +441,9 @@
     <header class="navbar">
       <div class="nav-inner">
         <div class="nav-brand">
-          <img id="site-logo" alt="Vectari logo" class="logo-full" />
+          <a href="https://vectari.co" target="_blank" rel="noopener">
+            <img id="site-logo" alt="Vectari logo" class="logo-full" />
+          </a>
         </div>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- Make the mini-assessment page's Vectari logo a clickable link that opens vectari.co

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a61313e5988328991eb239fdfd300e