### PR TITLE
Refine mini-assessment next steps messaging

### DIFF
--- a/mini-assessment/app.js
+++ b/mini-assessment/app.js
@@ -66,8 +66,10 @@
   const gapsTitleEl = document.getElementById("gaps-title");
   const gapsEl = document.getElementById("gaps");
   const nextStepsHeadingEl = document.getElementById("next-steps-heading");
-  const bandNoteEl = document.getElementById("band-note");
   const nextStepsBodyEl = document.getElementById("next-steps-body");
+  const nextStepsEncouragementEl = document.getElementById(
+    "next-steps-encouragement"
+  );
   const ctaEl = document.getElementById("next-steps-cta");
   const restartBtn = document.getElementById("restart");
   const scoreValueEl = document.getElementById("score-value");
@@ -93,6 +95,9 @@
     (config.nextSteps && config.nextSteps.heading) || "Next steps";
   nextStepsBodyEl.textContent =
     (config.nextSteps && config.nextSteps.body) || "";
+  nextStepsEncouragementEl.textContent =
+    (config.nextSteps && config.nextSteps.encouragement) ||
+    "You’ve already done the hardest part—getting a clear starting point. A short call can turn this into a practical 30-day plan.";
   ctaEl.textContent =
     (config.nextSteps && config.nextSteps.ctaLabel) || "";
   ctaEl.href =
@@ -375,11 +380,6 @@
     scoreBandEl.textContent = band.label;
     scoreBandEl.style.backgroundColor = zoneColor;
 
-    const bandKey = band.label.toLowerCase();
-    const bandNotes =
-      (config.nextSteps && config.nextSteps.bandNotes) || {};
-    bandNoteEl.textContent = bandNotes[bandKey] || "";
-
     const counts = {
       0: gapsBySeverity[0].length,
       1: gapsBySeverity[1].length,
@@ -586,7 +586,6 @@
     messageEl.textContent = "";
     scoreValueEl.textContent = "";
     scoreBandEl.textContent = "";
-    bandNoteEl.textContent = "";
     results.querySelectorAll(".fade-line").forEach((el) =>
       el.classList.remove("show"),
     );

--- a/mini-assessment/config.js
+++ b/mini-assessment/config.js
@@ -33,13 +33,8 @@ window.ASSESSMENT_CONFIG = {
   nextSteps: {
     heading: "Next steps",
     body: "Ten questions surface themes, not the full picture. If you’d like to walk through any questions or answers—and decide what to tackle first—we’re happy to help.",
-    bandNotes: {
-      high: "You have critical gaps—let’s triage the top risks first.",
-      medium: "A few focused improvements will close the biggest exposures.",
-      good: "You’re close—tighten the last gaps to reduce residual risk.",
-      perfect:
-        "Excellent baseline—keep it strong with periodic validation, and let's dive deeper.",
-    },
+    encouragement:
+      "You’ve already done the hardest part—getting a clear starting point. A short call can turn this into a practical 30-day plan.",
     ctaLabel: "Book a free consultation",
     ctaHref:
       "https://outlook.office.com/book/VectariIntroduction@vectari.co/?ismsaljsauthenabled",

--- a/mini-assessment/index.html
+++ b/mini-assessment/index.html
@@ -414,7 +414,12 @@
       }
       .next-steps p {
         margin: 0 0 12px;
-        color: var(--muted);
+        color: var(--text);
+      }
+      .next-steps .encouragement {
+        font-weight: 600;
+        margin: 20px 0;
+        color: var(--text);
       }
       #restart {
         margin-top: 12px;
@@ -513,8 +518,8 @@
           aria-labelledby="next-steps-heading"
         >
           <h2 id="next-steps-heading"></h2>
-          <p id="band-note"></p>
           <p id="next-steps-body"></p>
+          <p id="next-steps-encouragement" class="encouragement"></p>
           <a
             id="next-steps-cta"
             class="cta-button"


### PR DESCRIPTION
## Summary
- Remove band-specific note and present consistent next steps copy in white.
- Introduce an encouragement line before the booking CTA with semi-bold styling.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6181e8f2c83288f6cddc0bc6d798f