### PR TITLE
Refine Next steps layout on mini assessment results

### DIFF
--- a/mini-assessment/index.html
+++ b/mini-assessment/index.html
@@ -403,23 +403,32 @@
         text-align: center;
       }
       .next-steps {
-        margin-top: 40px;
+        margin: 40px auto 0;
         padding-top: 32px;
         border-top: 1px solid var(--border);
         text-align: center;
+        max-width: 680px;
       }
       .next-steps h2 {
-        margin: 0 0 12px;
+        margin: 0 0 28px;
         color: var(--accent-orange);
       }
-      .next-steps p {
-        margin: 0 0 12px;
-        color: var(--text);
+      #next-steps-body {
+        margin: 0 0 28px;
+        color: var(--muted);
       }
       .next-steps .encouragement {
         font-weight: 600;
-        margin: 20px 0;
+        margin: 0 0 28px;
         color: var(--text);
+      }
+      .next-steps .cta-button {
+        margin-top: 0;
+      }
+      .next-steps .subnote {
+        margin-top: 8px;
+        color: var(--muted);
+        font-size: 0.75rem;
       }
       #restart {
         margin-top: 12px;
@@ -526,6 +535,7 @@
             target="_blank"
             rel="noopener"
           ></a>
+          <p class="subnote">Your results stay private.</p>
         </section>
         <button id="restart" type="button" class="fade-line"></button>
       </section>


### PR DESCRIPTION
## Summary
- Constrain and center the Next steps block with a max-width layout and consistent divider spacing
- Differentiate body and encouragement text and tighten internal spacing for improved rhythm
- Add privacy subnote below CTA to reassure users

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a61de786388328a5683f07000f4444