### PR TITLE
Add hero scroll indicator

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,7 +70,12 @@
           <a href="https://outlook.office.com/book/VectariIntroduction@vectari.co/?ismsaljsauthenabled" class="button primary">Talk to a Security Expert</a>
         </div>
       </div>
-    </section>
+      <div class="scroll-indicator" role="button" aria-label="Keep Scrolling">
+        <div class="mouse" aria-hidden="true"><div class="wheel"></div></div>
+        <div class="arrow" aria-hidden="true"></div>
+        <span class="scroll-text">Keep Scrolling</span>
+    </div>
+  </section>
     <!-- Trust Bar: tweak :root vars for colors, --trust-speed for scroll speed, and edit <li> badges -->
     <section class="trust-bar" aria-label="Trust &amp; assurance">
       <div class="trust-viewport">

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -232,6 +232,74 @@ a:hover {
   margin-bottom: 0.5rem;
 }
 
+/* Scroll indicator at bottom of hero */
+.scroll-indicator {
+  position: absolute;
+  left: 50%;
+  bottom: calc(env(safe-area-inset-bottom) + 1rem);
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+  color: #fff;
+  opacity: 0.8;
+  cursor: pointer;
+  transition: opacity 0.3s;
+  min-width: 44px;
+  min-height: 44px;
+}
+.scroll-indicator.hide {
+  opacity: 0;
+  pointer-events: none;
+}
+.scroll-indicator .mouse {
+  width: 24px;
+  height: 40px;
+  border: 2px solid currentColor;
+  border-radius: 12px;
+  display: flex;
+  justify-content: center;
+}
+.scroll-indicator .wheel {
+  width: 4px;
+  height: 8px;
+  background: currentColor;
+  border-radius: 2px;
+  margin-top: 6px;
+  animation: scroll-wheel 1.5s infinite;
+}
+.scroll-indicator .arrow {
+  width: 10px;
+  height: 10px;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: rotate(45deg);
+  animation: scroll-arrow 1.5s infinite;
+}
+.scroll-indicator .scroll-text {
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+}
+
+@keyframes scroll-wheel {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(6px); }
+}
+
+@keyframes scroll-arrow {
+  0% { opacity: 0; transform: rotate(45deg) translateY(0); }
+  50% { opacity: 1; transform: rotate(45deg) translateY(4px); }
+  100% { opacity: 0; transform: rotate(45deg) translateY(8px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .scroll-indicator .wheel,
+  .scroll-indicator .arrow {
+    animation: none;
+  }
+}
+
 .button {
   display: inline-block;
   padding: 0.75rem 1.5rem;

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -23,4 +23,26 @@ document.addEventListener('DOMContentLoaded', function () {
       item.classList.toggle('active');
     });
   });
+  const scrollIndicator = document.querySelector('.scroll-indicator');
+  if (scrollIndicator) {
+    const nextSection = document.querySelector('#problems');
+    const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    scrollIndicator.addEventListener('click', function () {
+      if (nextSection) {
+        nextSection.scrollIntoView({ behavior: prefersReduced ? 'auto' : 'smooth' });
+      }
+    });
+
+    const toggleIndicator = function () {
+      if (window.scrollY > 10) {
+        scrollIndicator.classList.add('hide');
+      } else {
+        scrollIndicator.classList.remove('hide');
+      }
+    };
+
+    window.addEventListener('scroll', toggleIndicator);
+    toggleIndicator();
+  }
 });


### PR DESCRIPTION
## Summary
- Add hero scroll indicator prompting users to keep scrolling
- Style indicator with mobile-safe positioning and motion-reduced animations
- Smooth-scroll to next section and fade indicator on scroll

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a61e3d5b0483288d38292da94de19b