### PR TITLE
Add canonical links and sitemap to address indexing warning

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   <meta name="description" content="Vectari delivers enterprise‑grade cybersecurity programs for SMBs: vCISO, DFIR, compliance, and managed security.">
   <link rel="icon" type="image/png" href="static/assets/logo.png">
   <link rel="stylesheet" href="static/css/styles.css">
+  <link rel="canonical" href="https://vectari.co/">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-4HFEY2Y8K7"></script>
   <script>

--- a/mini-assessment/index.html
+++ b/mini-assessment/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="canonical" href="https://vectari.co/mini-assessment/" />
     <title>Mini Security Assessment</title>
     <style>
       :root {

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://vectari.co/sitemap.xml
+

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://vectari.co/</loc>
+  </url>
+  <url>
+    <loc>https://vectari.co/mini-assessment/</loc>
+  </url>
+  <url>
+    <loc>https://vectari.co/thank-you.html</loc>
+  </url>
+  <url>
+    <loc>https://vectari.co/thank-you-booking.html</loc>
+  </url>
+</urlset>
+

--- a/thank-you-booking.html
+++ b/thank-you-booking.html
@@ -6,6 +6,7 @@
   <title>Meeting Scheduled – Vectari</title>
   <link rel="icon" type="image/png" href="static/assets/logo.png">
   <link rel="stylesheet" href="static/css/styles.css">
+  <link rel="canonical" href="https://vectari.co/thank-you-booking.html">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-4HFEY2Y8K7"></script>
   <script>

--- a/thank-you.html
+++ b/thank-you.html
@@ -6,6 +6,7 @@
   <title>Thank You – Vectari</title>
   <link rel="icon" type="image/png" href="static/assets/logo.png">
   <link rel="stylesheet" href="static/css/styles.css">
+  <link rel="canonical" href="https://vectari.co/thank-you.html">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-4HFEY2Y8K7"></script>
   <script>


### PR DESCRIPTION
## Summary
- add canonical links to all public pages
- provide robots.txt and sitemap.xml to expose canonical URLs

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab293919ac832881c81d0f5796d567