### PR TITLE
feat: preconnect to gtag

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,8 @@
   <link rel="icon" type="image/png" href="static/assets/logo.png">
   <link rel="stylesheet" href="static/css/styles.css">
   <link rel="canonical" href="https://vectari.co/">
+  <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
+  <link rel="dns-prefetch" href="https://www.googletagmanager.com">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-4HFEY2Y8K7"></script>
   <script>


### PR DESCRIPTION
## Summary
- preconnect to Google Tag Manager for faster analytics loading
- hint browsers with DNS prefetch of Google Tag Manager domain

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af95c1d6d88328a49f2a4376a378d2