### PR TITLE
Throttle scroll indicator updates

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -34,15 +34,28 @@ document.addEventListener('DOMContentLoaded', function () {
       }
     });
 
-    const toggleIndicator = function () {
-      if (window.scrollY > 10) {
+    let lastKnownScrollY = 0;
+    let ticking = false;
+
+    const updateIndicator = function () {
+      if (lastKnownScrollY > 10) {
         scrollIndicator.classList.add('hide');
       } else {
         scrollIndicator.classList.remove('hide');
       }
+      ticking = false;
     };
 
-    window.addEventListener('scroll', toggleIndicator);
-    toggleIndicator();
+    const onScroll = function () {
+      lastKnownScrollY = window.scrollY;
+      if (!ticking) {
+        window.requestAnimationFrame(updateIndicator);
+        ticking = true;
+      }
+    };
+
+    window.addEventListener('scroll', onScroll, { passive: true });
+    lastKnownScrollY = window.scrollY;
+    updateIndicator();
   }
 });


### PR DESCRIPTION
## Summary
- Use `requestAnimationFrame` to throttle scroll indicator updates and cache `scrollY`
- Mark scroll listener as `{ passive: true }` for smoother scrolling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af9a85a6f083289dc93f2dfaa2f7b5