### PR TITLE
Add St. George cybersecurity page and footer link

### DIFF
--- a/index.html
+++ b/index.html
@@ -700,6 +700,8 @@
           <h4>Get in touch</h4>
           <p>info@vectari.co</p>
           <p>(301) 246‑0601</p>
+          <p>St. George, Utah • Serving clients across the United States</p>
+          <p><a href="/st-george-cybersecurity.html">Cybersecurity in St. George</a></p>
           <p><a href="#">Privacy Policy</a> · <a href="#">Terms</a></p>
         </div>
       </div>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -12,5 +12,8 @@
   <url>
     <loc>https://vectari.co/thank-you-booking.html</loc>
   </url>
+  <url>
+    <loc>https://vectari.co/st-george-cybersecurity.html</loc>
+  </url>
 </urlset>
 

--- a/st-george-cybersecurity.html
+++ b/st-george-cybersecurity.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cybersecurity in St. George, Utah – Vectari</title>
+  <link rel="icon" type="image/png" href="static/assets/logo.png">
+  <link rel="stylesheet" href="static/css/styles.css">
+  <link rel="canonical" href="https://vectari.co/st-george-cybersecurity.html">
+  <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
+  <link rel="dns-prefetch" href="https://www.googletagmanager.com">
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-4HFEY2Y8K7"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-4HFEY2Y8K7');
+  </script>
+</head>
+<body>
+  <div class="overlay">
+    <section class="section">
+      <h1>Cybersecurity in St. George, Utah</h1>
+      <p>Vectari delivers comprehensive cybersecurity services to businesses in St. George and across the United States.</p>
+      <p>Though headquartered in St. George, Utah, we proudly serve clients nationwide.</p>
+      <iframe src="https://www.google.com/maps?q=St+George,+UT&output=embed" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+      <p><a href="/">Back to home</a></p>
+    </section>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add St. George location and link to new page in footer
- Create `st-george-cybersecurity.html` with Google Map and nationwide service note
- Include new page in `sitemap.xml` for discovery
- Preconnect to Google Tag Manager and highlight nationwide service in footer

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68afa272e74083289f2b787b58977595