### PR TITLE
Align St George cybersecurity page header with main site

### DIFF
--- a/st-george-cybersecurity.html
+++ b/st-george-cybersecurity.html
@@ -1,32 +1,162 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Cybersecurity in St. George, Utah – Vectari</title>
-  <link rel="icon" type="image/png" href="static/assets/logo.png">
-  <link rel="stylesheet" href="static/css/styles.css">
-  <link rel="canonical" href="https://vectari.co/st-george-cybersecurity.html">
-  <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
-  <link rel="dns-prefetch" href="https://www.googletagmanager.com">
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-4HFEY2Y8K7"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-4HFEY2Y8K7');
-  </script>
-</head>
-<body>
-  <div class="overlay">
-    <section class="section">
-      <h1>Cybersecurity in St. George, Utah</h1>
-      <p>Vectari delivers comprehensive cybersecurity services to businesses in St. George and across the United States.</p>
-      <p>Though headquartered in St. George, Utah, we proudly serve clients nationwide.</p>
-      <iframe src="https://www.google.com/maps?q=St+George,+UT&output=embed" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
-      <p><a href="/">Back to home</a></p>
-    </section>
-  </div>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cybersecurity in St. George, Utah – Vectari</title>
+    <link rel="icon" type="image/png" href="static/assets/logo.png" />
+    <link rel="stylesheet" href="static/css/styles.css" />
+    <link
+      rel="canonical"
+      href="https://vectari.co/st-george-cybersecurity.html"
+    />
+    <link
+      rel="preconnect"
+      href="https://www.googletagmanager.com"
+      crossorigin
+    />
+    <link rel="dns-prefetch" href="https://www.googletagmanager.com" />
+    <!-- Google tag (gtag.js) -->
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-4HFEY2Y8K7"
+    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
+      gtag("config", "G-4HFEY2Y8K7");
+    </script>
+    <style>
+      :root {
+        --color-orange: #ff6a3d;
+        --font-family: "Inter", sans-serif;
+      }
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        font-family: var(--font-family);
+        background: #000;
+      }
+      a {
+        color: #0076d1;
+        text-decoration: none;
+      }
+      a:hover {
+        text-decoration: underline;
+      }
+      .navbar {
+        position: sticky;
+        top: 0;
+        background: linear-gradient(to bottom, #010c1f 0%, #00172c 100%);
+        z-index: 100;
+      }
+      .nav-inner {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 0.5rem 1rem;
+      }
+      .nav-brand {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        color: #fff;
+        font-weight: 600;
+        font-size: 1.4rem;
+      }
+      .nav-brand .logo-full {
+        height: 36px;
+        width: auto;
+      }
+      .nav-links {
+        display: none;
+      }
+      @media (min-width: 768px) {
+        .nav-links {
+          display: flex;
+          gap: 1.5rem;
+        }
+      }
+      .nav-links a {
+        color: #fff;
+        font-size: 0.9rem;
+        transition: opacity 0.2s;
+      }
+      .nav-links a:hover {
+        opacity: 0.8;
+      }
+      .cta-button {
+        display: inline-block;
+        padding: 0.5rem 1rem;
+        border-radius: 9999px;
+        background: var(--color-orange);
+        color: #fff;
+        font-weight: 600;
+        font-size: 0.85rem;
+        border: 2px solid var(--color-orange);
+        transition: background 0.2s;
+      }
+      .cta-button:hover {
+        background: transparent;
+        color: var(--color-orange);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="overlay">
+      <header class="navbar">
+        <div class="nav-inner">
+          <div class="nav-brand">
+            <img
+              src="static/assets/logo-bar.png"
+              alt="Vectari logo"
+              class="logo-full"
+            />
+          </div>
+          <nav class="nav-links">
+            <a href="/#problems">Challenges</a>
+            <a href="/#what-we-do">Services</a>
+            <a href="/#frameworks-carousel">Compliance</a>
+          </nav>
+          <a
+            href="https://outlook.office.com/book/VectariIntroduction@vectari.co/?ismsaljsauthenabled"
+            class="cta-button"
+            >Schedule a Call</a
+          >
+        </div>
+      </header>
+      <section class="section">
+        <h1>Cybersecurity in St. George, Utah</h1>
+        <p>
+          Vectari delivers comprehensive cybersecurity services to businesses in
+          St. George and across the United States.
+        </p>
+        <p>
+          Though headquartered in St. George, Utah, we proudly serve clients
+          nationwide.
+        </p>
+        <iframe
+          src="https://www.google.com/maps?q=St+George,+UT&output=embed"
+          width="600"
+          height="450"
+          style="border: 0"
+          allowfullscreen=""
+          loading="lazy"
+          referrerpolicy="no-referrer-when-downgrade"
+        ></iframe>
+        <p><a href="/">Back to home</a></p>
+      </section>
+    </div>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- Add branded sticky navigation bar to St. George cybersecurity page using main-site colors and logo
- Include main page navigation links and "Schedule a Call" CTA

## Testing
- `npx prettier --check st-george-cybersecurity.html`


------
https://chatgpt.com/codex/tasks/task_e_68afa5d9b55483289540c2ecd00fe451