### PR TITLE
Streamline St. George location hero

### DIFF
--- a/st-george-cybersecurity.html
+++ b/st-george-cybersecurity.html
@@ -4,14 +4,27 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Cybersecurity Services in St. George, Utah | Vectari</title>
-    <meta name="description" content="Vectari delivers CISO-led cybersecurity and compliance services to businesses in St. George, Utah, and nationwide. Protect your business today." />
+    <meta
+      name="description"
+      content="Vectari delivers CISO-led cybersecurity and compliance services to businesses in St. George, Utah, and nationwide. Protect your business today."
+    />
     <link rel="icon" type="image/png" href="static/assets/logo.png" />
     <link rel="stylesheet" href="static/css/styles.css" />
-    <link rel="canonical" href="https://vectari.co/st-george-cybersecurity.html" />
-    <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin />
+    <link
+      rel="canonical"
+      href="https://vectari.co/st-george-cybersecurity.html"
+    />
+    <link
+      rel="preconnect"
+      href="https://www.googletagmanager.com"
+      crossorigin
+    />
     <link rel="dns-prefetch" href="https://www.googletagmanager.com" />
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-4HFEY2Y8K7"></script>
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-4HFEY2Y8K7"
+    ></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag() {
@@ -91,21 +104,39 @@
         opacity: 0.8;
       }
       .cta-button,
-      .button.primary {
+      .button {
         display: inline-block;
         padding: 0.75rem 1.5rem;
         border-radius: 9999px;
-        background: var(--color-orange);
-        color: #fff;
         font-weight: 600;
         font-size: 0.9rem;
-        border: 2px solid var(--color-orange);
+        border: 2px solid transparent;
         transition: all 0.2s;
+      }
+      .cta-button,
+      .button.primary {
+        background: var(--color-orange);
+        border-color: var(--color-orange);
+        color: #fff;
       }
       .cta-button:hover,
       .button.primary:hover {
         background: transparent;
         color: var(--color-orange);
+      }
+      .button.secondary {
+        background: var(--color-blue);
+        border-color: var(--color-blue);
+        color: #fff;
+      }
+      .button.secondary:hover {
+        background: transparent;
+        color: var(--color-blue);
+      }
+      .cta-button:focus-visible,
+      .button:focus-visible {
+        outline: 2px solid #fff;
+        outline-offset: 2px;
       }
       .overlay {
         color: #fff;
@@ -145,7 +176,9 @@
         gap: 0.75rem;
         position: relative;
         overflow: hidden;
-        transition: box-shadow 0.3s, transform 0.3s;
+        transition:
+          box-shadow 0.3s,
+          transform 0.3s;
         flex: 1;
       }
       .cards article::before {
@@ -154,8 +187,15 @@
         inset: 0;
         padding: 1px;
         border-radius: inherit;
-        background: conic-gradient(var(--color-navy), var(--color-blue), var(--color-orange), var(--color-navy));
-        -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+        background: conic-gradient(
+          var(--color-navy),
+          var(--color-blue),
+          var(--color-orange),
+          var(--color-navy)
+        );
+        -webkit-mask:
+          linear-gradient(#000 0 0) content-box,
+          linear-gradient(#000 0 0);
         -webkit-mask-composite: xor;
         mask-composite: exclude;
         pointer-events: none;
@@ -174,36 +214,41 @@
         margin: 0;
       }
       .cards article:hover {
-        box-shadow: 0 8px 16px -4px rgba(0, 0, 0, 0.6), 0 0 8px 2px var(--color-blue);
+        box-shadow:
+          0 8px 16px -4px rgba(0, 0, 0, 0.6),
+          0 0 8px 2px var(--color-blue);
         transform: translateY(-4px);
       }
       .location-hero {
-        position: relative;
-        overflow: hidden;
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        align-items: center;
-        text-align: center;
-        min-height: 60vh;
-        padding: 4rem 1rem;
+        background: linear-gradient(to bottom, #00172c, #000);
+        padding: 48px 1rem;
       }
-      .location-hero::before {
-        content: "";
-        position: absolute;
-        inset: 0;
-        background: linear-gradient(135deg, rgba(0, 118, 209, 0.5), rgba(16, 181, 166, 0.5));
-        z-index: -1;
+      .location-hero .hero-content {
+        max-width: 1040px;
+        margin: 0 auto;
+        text-align: center;
       }
       .location-hero h1 {
-        margin: 0 0 20px;
+        margin: 0 0 8px;
         color: #fff;
-        font-size: clamp(2rem, 5vw, 3rem);
+        font-size: clamp(1.75rem, 4vw, 2.5rem);
+        line-height: 1.2;
       }
       .location-hero p {
-        margin: 0 0 20px;
+        margin: 0 0 16px;
         color: #e5e7eb;
         font-size: 1.125rem;
+      }
+      .hero-actions {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        justify-content: center;
+      }
+      @media (min-width: 768px) {
+        .hero-actions {
+          flex-direction: row;
+        }
       }
       .map-card {
         max-width: 800px;
@@ -254,18 +299,34 @@
             Vectari is headquartered in St. George, delivering enterprise-grade
             cybersecurity locally and nationwide.
           </p>
+          <div class="hero-actions">
+            <a
+              href="https://outlook.office.com/book/VectariIntroduction@vectari.co/?ismsaljsauthenabled"
+              class="button primary"
+              >Schedule a Call</a
+            >
+            <a href="#services" class="button secondary">See services</a>
+          </div>
         </div>
       </section>
 
-      <section class="section">
+      <section class="section" id="services">
         <h2>Local Expertise, National Reach</h2>
         <ul class="cards">
           <li>
             <article>
               <!-- map-pin icon -->
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                <path d="M21 10c0 7-9 13-9 13S3 17 3 10a9 9 0 0 1 18 0z"/>
-                <circle cx="12" cy="10" r="3"/>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M21 10c0 7-9 13-9 13S3 17 3 10a9 9 0 0 1 18 0z" />
+                <circle cx="12" cy="10" r="3" />
               </svg>
               <h3>Local roots</h3>
               <p>Our team lives and works in southern Utah.</p>
@@ -274,10 +335,20 @@
           <li>
             <article>
               <!-- globe icon -->
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                <circle cx="12" cy="12" r="10"/>
-                <line x1="2" y1="12" x2="22" y2="12"/>
-                <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <circle cx="12" cy="12" r="10" />
+                <line x1="2" y1="12" x2="22" y2="12" />
+                <path
+                  d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"
+                />
               </svg>
               <h3>National reach</h3>
               <p>Enterprise-grade solutions for clients across the U.S.</p>
@@ -292,8 +363,16 @@
           <li>
             <article>
               <!-- shield icon -->
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
               </svg>
               <h3>Risk Assessments</h3>
             </article>
@@ -301,9 +380,19 @@
           <li>
             <article>
               <!-- checklist icon -->
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                <path d="M9 11l3 3L22 4"/>
-                <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M9 11l3 3L22 4" />
+                <path
+                  d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"
+                />
               </svg>
               <h3>Compliance Readiness</h3>
             </article>
@@ -311,11 +400,19 @@
           <li>
             <article>
               <!-- user-tie icon -->
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                <circle cx="12" cy="7" r="4"/>
-                <path d="M4 21v-2a4 4 0 0 1 4-4h8a4 4 0 0 1 4 4v2"/>
-                <path d="M12 11v4"/>
-                <path d="M10 15l2 3 2-3"/>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <circle cx="12" cy="7" r="4" />
+                <path d="M4 21v-2a4 4 0 0 1 4-4h8a4 4 0 0 1 4 4v2" />
+                <path d="M12 11v4" />
+                <path d="M10 15l2 3 2-3" />
               </svg>
               <h3>Fractional CISO</h3>
             </article>
@@ -323,9 +420,19 @@
           <li>
             <article>
               <!-- settings/gear icon -->
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                <circle cx="12" cy="12" r="3"/>
-                <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 8.6 19a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33h.09a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51h.09a1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82v.09a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <circle cx="12" cy="12" r="3" />
+                <path
+                  d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 8.6 19a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33h.09a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51h.09a1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82v.09a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"
+                />
               </svg>
               <h3>MSP Services</h3>
             </article>
@@ -333,11 +440,19 @@
           <li>
             <article>
               <!-- link-check icon -->
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                <path d="M15 7h3a5 5 0 0 1 0 10h-3"/>
-                <path d="M9 17H6a5 5 0 0 1 0-10h3"/>
-                <path d="M8 12h8"/>
-                <polyline points="16 18 18 20 22 16"/>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M15 7h3a5 5 0 0 1 0 10h-3" />
+                <path d="M9 17H6a5 5 0 0 1 0-10h3" />
+                <path d="M8 12h8" />
+                <polyline points="16 18 18 20 22 16" />
               </svg>
               <h3>Vendor Risk Automation</h3>
             </article>
@@ -351,9 +466,17 @@
           <li>
             <article>
               <!-- map-pin icon -->
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                <path d="M21 10c0 7-9 13-9 13S3 17 3 10a9 9 0 0 1 18 0z"/>
-                <circle cx="12" cy="10" r="3"/>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M21 10c0 7-9 13-9 13S3 17 3 10a9 9 0 0 1 18 0z" />
+                <circle cx="12" cy="10" r="3" />
               </svg>
               <h3>Local presence in St. George</h3>
             </article>
@@ -361,8 +484,16 @@
           <li>
             <article>
               <!-- shield icon -->
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
               </svg>
               <h3>Enterprise cybersecurity expertise</h3>
             </article>
@@ -370,9 +501,17 @@
           <li>
             <article>
               <!-- trending-up icon -->
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                <polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/>
-                <polyline points="17 6 23 6 23 12"/>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <polyline points="23 6 13.5 15.5 8.5 10.5 1 18" />
+                <polyline points="17 6 23 6 23 12" />
               </svg>
               <h3>Scalable solutions that grow with you</h3>
             </article>


### PR DESCRIPTION
## Summary
- Replace St. George location hero with compact dark block and reduced typography.
- Add immediate "Schedule a Call" and "See services" buttons with accessible focus styles.
- Anchor services section for quick navigation.

## Testing
- `npx prettier -w st-george-cybersecurity.html`
- `npx htmlhint st-george-cybersecurity.html` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68afb8f696b48328a1fed8b7aebba381