### PR TITLE
Add robots and description meta tags to thank-you pages

### DIFF
--- a/thank-you-booking.html
+++ b/thank-you-booking.html
@@ -3,6 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex, nofollow">
+  <meta name="description" content="Brief statement acknowledging form submission or booking." />
   <title>Meeting Scheduled – Vectari</title>
   <link rel="icon" type="image/png" href="static/assets/logo.png">
   <link rel="stylesheet" href="static/css/styles.css">

--- a/thank-you.html
+++ b/thank-you.html
@@ -3,6 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex, nofollow">
+  <meta name="description" content="Brief statement acknowledging form submission or booking." />
   <title>Thank You – Vectari</title>
   <link rel="icon" type="image/png" href="static/assets/logo.png">
   <link rel="stylesheet" href="static/css/styles.css">


### PR DESCRIPTION
## Summary
- prevent search indexing by adding `noindex, nofollow` robots meta tags to thank-you pages
- add brief description meta tag to give context if crawled

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68afce0c193083288fc16a111fe2325c