### PR TITLE
Add meta description for mini security assessment

### DIFF
--- a/mini-assessment/index.html
+++ b/mini-assessment/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Mini security assessment exposes vulnerabilities fast, delivers actionable insights, and strengthens data protection against cyber threats for your business."
+    />
     <link rel="canonical" href="https://vectari.co/mini-assessment/" />
     <title>Mini Security Assessment</title>
     <!-- Google tag (gtag.js) -->


### PR DESCRIPTION
## Summary
- add SEO-friendly meta description for the Mini Security Assessment page

## Testing
- `npx prettier -c mini-assessment/index.html` *(fails: Code style issues found)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68afe29f59bc83289a473fa06a1313cc