### PR TITLE
Revamp mini assessment next steps section

### DIFF
--- a/mini-assessment/app.js
+++ b/mini-assessment/app.js
@@ -67,9 +67,7 @@
   const gapsEl = document.getElementById("gaps");
   const nextStepsHeadingEl = document.getElementById("next-steps-heading");
   const nextStepsBodyEl = document.getElementById("next-steps-body");
-  const nextStepsEncouragementEl = document.getElementById(
-    "next-steps-encouragement"
-  );
+  const nextStepsListEl = document.getElementById("next-steps-list");
   const ctaEl = document.getElementById("next-steps-cta");
   const restartBtn = document.getElementById("restart");
   const scoreValueEl = document.getElementById("score-value");
@@ -93,11 +91,14 @@
     (config.texts && config.texts.gapsTitle) || "Opportunities for improvement";
   nextStepsHeadingEl.textContent =
     (config.nextSteps && config.nextSteps.heading) || "Next steps";
-  nextStepsBodyEl.textContent =
+  let nextStepsBodyTemplate =
     (config.nextSteps && config.nextSteps.body) || "";
-  nextStepsEncouragementEl.textContent =
-    (config.nextSteps && config.nextSteps.encouragement) ||
-    "You’ve already done the hardest part—getting a clear starting point. A short call can turn this into a practical 30-day plan.";
+  const nextStepsItems = (config.nextSteps && config.nextSteps.items) || [];
+  nextStepsItems.forEach((item) => {
+    const li = document.createElement("li");
+    li.textContent = item;
+    nextStepsListEl.appendChild(li);
+  });
   ctaEl.textContent =
     (config.nextSteps && config.nextSteps.ctaLabel) || "";
   ctaEl.href =
@@ -357,6 +358,10 @@
     });
     const max = fieldsets.length * 3;
     scoreValueEl.setAttribute("aria-label", `Score ${total} out of ${max}`);
+    nextStepsBodyEl.textContent = nextStepsBodyTemplate.replace(
+      "{{score}}",
+      `${total}/${max}`,
+    );
     const range =
       config.ranges &&
       config.ranges.find((r) => total >= r.min && total <= r.max);

--- a/mini-assessment/config.js
+++ b/mini-assessment/config.js
@@ -32,10 +32,14 @@ window.ASSESSMENT_CONFIG = {
   },
   nextSteps: {
     heading: "Next steps",
-    body: "Ten questions surface themes, not the full picture. If you’d like to walk through any questions or answers—and decide what to tackle first—we’re happy to help.",
-    encouragement:
-      "You’ve already done the hardest part—getting a clear starting point. A short call can turn this into a practical 30-day plan.",
-    ctaLabel: "Book a free consultation",
+    body:
+      "You’ve got a clear starting point - nice work! Your score of {{score}} shows gaps that attackers (and auditors) can exploit. Let’s turn this into action:",
+    items: [
+      "Walk your results with a CISO (free, 30 minutes)",
+      "Get a custom 30-day plan to close your top 3 risks",
+      "Know the exact fixes to prioritize (no fluff, no upsell)",
+    ],
+    ctaLabel: "Turn my score into a 30-day plan!",
     ctaHref:
       "https://outlook.office.com/book/VectariIntroduction@vectari.co/?ismsaljsauthenabled",
   },

--- a/mini-assessment/index.html
+++ b/mini-assessment/index.html
@@ -431,10 +431,12 @@
         margin: 0 0 28px;
         color: var(--muted);
       }
-      .next-steps .encouragement {
-        font-weight: 600;
+      .next-steps ul {
+        list-style: disc;
+        padding-left: 20px;
         margin: 0 0 28px;
-        color: var(--text);
+        text-align: left;
+        color: var(--muted);
       }
       .next-steps .cta-button {
         margin-top: 0;
@@ -547,7 +549,7 @@
         >
           <h2 id="next-steps-heading"></h2>
           <p id="next-steps-body"></p>
-          <p id="next-steps-encouragement" class="encouragement"></p>
+          <ul id="next-steps-list"></ul>
           <a
             id="next-steps-cta"
             class="cta-button"
@@ -555,6 +557,7 @@
             rel="noopener"
           ></a>
           <p class="subnote">Your results stay private.</p>
+          <p class="subnote">Limited review slots each week.</p>
         </section>
         <button id="restart" type="button" class="fade-line"></button>
       </section>


### PR DESCRIPTION
## Summary
- Revise mini assessment next steps copy and CTA with dynamic score support and bullet list of actions.
- Add note about limited weekly review slots and keep results private message.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b14461e50c83288e1877629dbd1d76