### PR TITLE
Revamp mini assessment results page

### DIFF
--- a/mini-assessment/index.html
+++ b/mini-assessment/index.html
@@ -39,18 +39,51 @@
       .navbar {
         position: sticky;
         top: 0;
-        background: linear-gradient(to bottom, #010c1f 0%, #00172C 100%);
+        background: linear-gradient(to bottom, #010c1f 0%, #00172c 100%);
         z-index: 100;
+        transition: box-shadow 0.2s ease;
+      }
+      .navbar.scrolled {
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
       }
       .nav-inner {
         display: flex;
         align-items: center;
-        justify-content: center;
+        justify-content: space-between;
         padding: 0.5rem 1rem;
+        max-width: 960px;
+        margin: 0 auto;
+      }
+      .nav-brand {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
       }
       .nav-brand .logo-full {
         height: 36px;
         width: auto;
+      }
+      .visit-main {
+        font-size: 11px;
+        color: #999;
+        text-decoration: none;
+        margin-top: 2px;
+      }
+      .nav-cta {
+        background: var(--accent-orange);
+        color: #fff;
+        text-decoration: none;
+        padding: 8px 16px;
+        border-radius: 999px;
+        font-weight: 600;
+        line-height: 1;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        height: 40px;
+      }
+      .nav-cta.hidden {
+        display: none;
       }
       .container {
         flex: 1;
@@ -208,19 +241,14 @@
         display: none;
       }
       .results-content {
-        display: grid;
-        grid-template-columns: 1fr;
-        justify-items: stretch;
-        align-items: flex-start;
-        gap: 20px;
-        margin-top: 20px;
+        text-align: center;
+        margin-top: 24px;
         background: var(--surface);
         color: var(--text);
         border-radius: var(--radius-card);
         box-shadow: var(--shadow),
           0 0 0 var(--stroke-inner) var(--stroke-white) inset;
-        padding: 24px;
-        overflow: visible;
+        padding: 24px 24px 0;
         opacity: 0;
         transform: translateY(24px);
         transition: opacity 0.2s ease-out, transform 0.2s ease-out,
@@ -230,18 +258,79 @@
         opacity: 1;
         transform: translateY(0);
       }
-      @media (min-width: 768px) {
-        .results-content {
-          grid-template-columns: auto minmax(0, 1fr);
-        }
-      }
       #severity-chart {
+        position: relative;
         display: flex;
-        flex-direction: column;
         align-items: center;
         justify-content: center;
-        gap: 8px;
-        justify-self: center;
+        margin: 12px auto 16px;
+      }
+      .score-overlay {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        text-align: center;
+      }
+      #score-value {
+        font-size: 36px;
+        font-weight: 700;
+        display: block;
+      }
+      #score-grade {
+        font-size: 14px;
+        color: #777;
+        display: block;
+        margin-top: 4px;
+      }
+      @media (min-width: 768px) {
+        #score-value {
+          font-size: 48px;
+        }
+        #score-grade {
+          font-size: 16px;
+        }
+      }
+      .divider {
+        border-top: 1px solid #ddd;
+        margin-top: 24px;
+      }
+      .info-block {
+        background: #f9fafb;
+        color: #111;
+        border-radius: 16px;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+        padding: 24px 20px;
+        margin: 32px 0;
+      }
+      .info-block h2 {
+        font-size: 20px;
+        margin: 0 0 16px;
+      }
+      .bullet-list {
+        list-style: disc;
+        padding-left: 20px;
+        margin: 0 0 20px;
+      }
+      .bullet-list li + li {
+        margin-top: 12px;
+      }
+      .reassurance {
+        font-size: 13px;
+        color: #888;
+        margin: 0;
+      }
+      .section-divider {
+        border-top: 1px solid #ddd;
+        margin: 20px 0;
+      }
+      @media (min-width: 768px) {
+        .info-block h2 {
+          font-size: 24px;
+        }
+        .bullet-list li + li {
+          margin-top: 16px;
+        }
       }
       .severity-donut {
         width: var(--donut-size);
@@ -290,31 +379,17 @@
       }
       .score-heading {
         font-weight: 700;
-        margin: 0 0 8px;
+        margin: 0;
+        font-size: 20px;
       }
-      .score-row {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-        font-size: 1.5rem;
-        font-weight: 600;
-        margin-bottom: 12px;
+      @media (min-width: 768px) {
+        .score-heading {
+          font-size: 24px;
+        }
       }
-      .score-band {
-        padding: 2px 8px;
-        border-radius: 6px;
-        font-size: 0.875rem;
-        font-weight: 600;
-        color: var(--text);
-      }
-      .results-text h3 {
-        color: var(--accent-orange);
-        margin: 0 0 12px;
-        line-height: 1.3;
-      }
-      .results-text p {
+      #result-message {
         color: var(--muted);
-        margin: 0 0 12px;
+        margin: 0 0 24px;
       }
       .fade-line {
         opacity: 0;
@@ -407,44 +482,17 @@
         grid-column: 1 / -1;
       }
       .cta-button {
-        display: inline-block;
-        margin-top: 20px;
         background: var(--accent-orange);
-        color: var(--text);
-        padding: 12px 24px;
-        border-radius: 999px;
+        color: #fff;
         text-decoration: none;
-        text-align: center;
-      }
-      .next-steps {
-        margin: 40px auto 0;
-        padding-top: 32px;
-        border-top: 1px solid var(--border);
-        text-align: center;
-        max-width: 680px;
-      }
-      .next-steps h2 {
-        margin: 0 0 28px;
-        color: var(--accent-orange);
-      }
-      #next-steps-body {
-        margin: 0 0 28px;
-        color: var(--muted);
-      }
-      .next-steps ul {
-        list-style: disc;
-        padding-left: 20px;
-        margin: 0 0 28px;
-        text-align: left;
-        color: var(--muted);
-      }
-      .next-steps .cta-button {
-        margin-top: 0;
-      }
-      .next-steps .subnote {
-        margin-top: 8px;
-        color: var(--muted);
-        font-size: 0.75rem;
+        padding: 8px 16px;
+        border-radius: 999px;
+        font-weight: 600;
+        line-height: 1;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        height: 40px;
       }
       #restart {
         margin-top: 12px;
@@ -456,6 +504,46 @@
         display: block;
         margin-left: auto;
         margin-right: auto;
+      }
+      #results {
+        padding-bottom: 72px;
+      }
+      .cta-bar {
+        position: fixed;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: var(--header-navy);
+        color: #eee;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 12px 16px;
+        box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.3);
+        transform: translateY(100%);
+        opacity: 0;
+        transition: transform 0.3s ease, opacity 0.3s ease;
+        z-index: 101;
+      }
+      .cta-bar.show {
+        transform: translateY(0);
+        opacity: 1;
+      }
+      .cta-bar .cta-text {
+        margin-right: 16px;
+      }
+      @media (max-width: 480px) {
+        .cta-bar {
+          flex-direction: column;
+          align-items: stretch;
+        }
+        .cta-bar .cta-text {
+          margin-right: 0;
+          margin-bottom: 8px;
+        }
+        .cta-bar .cta-button {
+          width: 100%;
+        }
       }
       .assessment-heading {
         color: #FF6A3D;
@@ -481,7 +569,7 @@
     <header class="navbar">
       <div class="nav-inner">
         <div class="nav-brand">
-          <a href="https://vectari.co" target="_blank" rel="noopener">
+          <a href="https://vectari.co/#hero">
             <img
               id="site-logo"
               src="/static/assets/logo-bar.png"
@@ -489,7 +577,17 @@
               class="logo-full"
             />
           </a>
+          <a href="https://vectari.co" class="visit-main" target="_blank" rel="noopener"
+            >Visit main site</a
+          >
         </div>
+        <a
+          id="nav-cta"
+          class="nav-cta"
+          target="_blank"
+          rel="noopener"
+          >Book Free Expert Review</a
+        >
       </div>
     </header>
     <main class="container">
@@ -528,40 +626,49 @@
         ></div>
       </div>
       <section id="results" hidden tabindex="-1">
-        <div class="results-content">
-          <div id="severity-chart"></div>
-          <div class="results-text">
-            <h2 class="score-heading fade-line">Your score</h2>
-            <div class="score-row fade-line">
+        <div id="score-block" class="results-content">
+          <h2 class="score-heading fade-line">Your Cybersecurity Risk Score</h2>
+          <div id="severity-chart" class="fade-line">
+            <div class="score-overlay">
               <span id="score-value"></span>
-              <span id="score-band" class="score-band"></span>
+              <span id="score-grade" class="score-grade"></span>
             </div>
-            <h3 id="result-headline" class="fade-line"></h3>
-            <p id="result-message" class="fade-line"></p>
           </div>
-          <h4 id="gaps-title" class="fade-line" hidden></h4>
-          <div id="gaps" class="gaps fade-line" hidden></div>
+          <p id="result-message" class="fade-line"></p>
+          <div class="divider fade-line"></div>
         </div>
-        <section
-          id="next-steps"
-          class="next-steps fade-line"
-          aria-labelledby="next-steps-heading"
-        >
-          <h2 id="next-steps-heading"></h2>
-          <p id="next-steps-body"></p>
-          <ul id="next-steps-list"></ul>
-          <a
-            id="next-steps-cta"
-            class="cta-button"
-            target="_blank"
-            rel="noopener"
-          ></a>
-          <p class="subnote">Your results stay private.</p>
-          <p class="subnote">Limited review slots each week.</p>
+        <section id="guidance" class="info-block fade-line">
+          <h2>Next steps: close your top 3 risks in 30 days.</h2>
+          <ul class="bullet-list">
+            <li>Walk through your score with a security expert (30 minutes).</li>
+            <li>Get a 30-day action plan with clear owners + fixes.</li>
+            <li>Know cost/effort before you commit.</li>
+          </ul>
+          <p class="reassurance">We’ll keep your results 100% private.</p>
+          <div class="section-divider"></div>
+          <h2>What happens in your free 30-minute review.</h2>
+          <ul class="bullet-list">
+            <li>Walk through your score with a security expert.</li>
+            <li>Pinpoint your top 3 risks and the fastest fixes.</li>
+            <li>Leave with a 30-day plan you can act on immediately.</li>
+          </ul>
+          <p class="reassurance">No pitch — just clear, actionable steps.</p>
         </section>
+        <h4 id="gaps-title" class="fade-line" hidden></h4>
+        <div id="gaps" class="gaps fade-line" hidden></div>
         <button id="restart" type="button" class="fade-line"></button>
       </section>
     </main>
+    <div id="sticky-cta" class="cta-bar">
+      <span class="cta-text">Free Expert Review — fix your top risks fast.</span>
+      <a
+        id="sticky-cta-button"
+        class="cta-button"
+        target="_blank"
+        rel="noopener"
+        >Book Now</a
+      >
+    </div>
     <script defer src="config.js"></script>
     <script defer src="app.js"></script>
   </body>


### PR DESCRIPTION
## Summary
- Implement sticky top navigation with logo link, "Visit main site" text, and booking CTA
- Overhaul results layout with donut score, grade, guidance sections, and sticky booking bar
- Add dynamic UTM links, analytics events, and scrolling behavior for CTAs

## Testing
- ❌ `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68b1ebabbdbc832881d7eb4c4248cc47