### PR TITLE
Refine mini-assessment results presentation

### DIFF
--- a/mini-assessment/index.html
+++ b/mini-assessment/index.html
@@ -42,11 +42,17 @@
         top: 0;
         background: var(--header-navy);
         z-index: 100;
-        transition: box-shadow 0.2s ease;
+        transition: box-shadow 0.2s ease, opacity 0.2s ease,
+          transform 0.2s ease;
         height: 60px;
       }
       .navbar.scrolled {
         box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+      }
+      .navbar.hidden {
+        opacity: 0;
+        transform: translateY(-8px);
+        pointer-events: none;
       }
       @media (min-width: 768px) {
         .navbar {
@@ -95,9 +101,12 @@
         align-items: center;
         justify-content: center;
         height: 40px;
+        transition: opacity 0.2s ease, transform 0.2s ease;
       }
       .nav-cta.hidden {
-        display: none;
+        opacity: 0;
+        transform: translateY(-8px);
+        pointer-events: none;
       }
       .container {
         flex: 1;
@@ -284,19 +293,28 @@
         opacity: 1;
         transform: translateY(0);
       }
+      #score-block {
+        padding-bottom: 16px;
+      }
       #severity-chart {
-        position: relative;
         display: flex;
+        flex-direction: column;
         align-items: center;
         justify-content: center;
         margin: 0 auto;
       }
+      .chart-holder {
+        position: relative;
+        width: var(--donut-size);
+        height: var(--donut-size);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-shrink: 0;
+      }
       .score-overlay {
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        transform: translate(-50%, -50%);
         text-align: center;
+        margin-top: 16px;
       }
       #score-value {
         font-size: 36px;
@@ -305,7 +323,7 @@
       }
       #score-grade {
         font-size: 14px;
-        color: #777;
+        color: #888;
         display: block;
         margin-top: 4px;
       }
@@ -315,6 +333,13 @@
         }
         #score-grade {
           font-size: 16px;
+        }
+        .score-overlay {
+          position: absolute;
+          top: 50%;
+          left: 50%;
+          transform: translate(-50%, -50%);
+          margin-top: 0;
         }
       }
       #result-message {
@@ -339,6 +364,9 @@
         padding: 24px 20px;
         margin: 32px 0;
       }
+      #guidance {
+        background: #f9fafb;
+      }
       .info-block h2 {
         font-size: 20px;
         margin: 0 0 12px;
@@ -356,6 +384,7 @@
         font-size: 13px;
         color: #888;
         margin-top: 16px;
+        padding-left: 20px;
       }
       .section-divider {
         border-top: 1px solid #ddd;
@@ -367,6 +396,9 @@
         }
         .info-block h2 {
           font-size: 24px;
+        }
+        #gaps-title {
+          font-size: 20px;
         }
       }
       .severity-donut {
@@ -382,11 +414,10 @@
       .severity-legend {
         list-style: none;
         padding: 0;
-        margin: 0;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        gap: 4px;
+        margin: 16px 0 0;
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 8px 16px;
         font-size: 0.75rem;
       }
       .severity-legend li {
@@ -399,6 +430,18 @@
         height: 10px;
         border-radius: 2px;
         flex-shrink: 0;
+      }
+      @media (min-width: 768px) {
+        #severity-chart {
+          flex-direction: row;
+        }
+        .severity-legend {
+          display: flex;
+          flex-direction: column;
+          align-items: flex-start;
+          margin: 0 0 0 24px;
+          gap: 8px;
+        }
       }
       @media (prefers-reduced-motion: reduce) {
         .results-content {
@@ -518,6 +561,7 @@
         margin: 48px 0 16px;
         padding-bottom: 8px;
         border-bottom: 1px solid #ddd;
+        font-size: 18px;
       }
       .cta-button {
         background: var(--accent-orange);
@@ -657,9 +701,11 @@
         <div id="score-block" class="results-content">
           <h2 class="score-heading fade-line">Your Cybersecurity Risk Score</h2>
           <div id="severity-chart" class="fade-line">
-            <div class="score-overlay">
-              <span id="score-value"></span>
-              <span id="score-grade" class="score-grade"></span>
+            <div class="chart-holder">
+              <div class="score-overlay">
+                <span id="score-value"></span>
+                <span id="score-grade" class="score-grade"></span>
+              </div>
             </div>
           </div>
           <p id="result-message" class="fade-line"></p>


### PR DESCRIPTION
## Summary
- fade entire nav bar when sticky bottom CTA appears
- place score and grade within donut on desktop and below on mobile
- apply light gray background to next steps section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2023ff96c832892e36f0132fe6819