### PR TITLE
Merge next steps into single review card

### DIFF
--- a/mini-assessment/index.html
+++ b/mini-assessment/index.html
@@ -365,10 +365,6 @@
         padding: 24px 20px;
         margin: 32px 0;
       }
-      #guidance {
-        background: var(--surface);
-        color: var(--text);
-      }
       .info-block h2 {
         font-size: 20px;
         margin: 0 0 12px;
@@ -387,10 +383,6 @@
         color: #888;
         margin-top: 16px;
         padding-left: 20px;
-      }
-      .section-divider {
-        border-top: 1px solid #ddd;
-        margin: 20px 0;
       }
       @media (min-width: 768px) {
         .info-block {
@@ -666,7 +658,7 @@
           class="nav-cta"
           target="_blank"
           rel="noopener"
-          >Book Free Expert Review</a
+          >Book Free 30-Minute Review</a
         >
       </div>
     </header>
@@ -720,21 +712,14 @@
           <div class="divider fade-line"></div>
         </div>
         <section id="guidance" class="info-block fade-line">
-          <h2>Next steps: close your top 3 risks in 30 days.</h2>
+          <h2>Your Free 30-Minute Security Review</h2>
           <ul class="bullet-list">
-            <li>Walk through your score with a security expert (30 minutes).</li>
-            <li>Get a 30-day action plan with clear owners + fixes.</li>
-            <li>Know cost/effort before you commit.</li>
+            <li><strong>Expert walkthrough</strong> — review your score with a security expert.</li>
+            <li><strong>Top 3 risks</strong> — see the fastest fixes for your biggest gaps.</li>
+            <li><strong>30-day action plan</strong> — clear owners + next steps, ready to use.</li>
+            <li><strong>No surprises</strong> — know time + effort before you commit.</li>
           </ul>
-          <p class="reassurance">We’ll keep your results 100% private.</p>
-          <div class="section-divider"></div>
-          <h2>What happens in your free 30-minute review.</h2>
-          <ul class="bullet-list">
-            <li>Walk through your score with a security expert.</li>
-            <li>Pinpoint your top 3 risks and the fastest fixes.</li>
-            <li>Leave with a 30-day plan you can act on immediately.</li>
-          </ul>
-          <p class="reassurance">No pitch — just clear, actionable steps.</p>
+          <p class="reassurance">No pitch — your results stay private.</p>
         </section>
         <h4 id="gaps-title" class="fade-line" hidden></h4>
         <div id="gaps" class="gaps fade-line" hidden></div>
@@ -743,7 +728,7 @@
     </main>
     <div id="sticky-cta" class="cta-bar">
       <div class="cta-inner">
-        <span class="cta-text">Free Expert Review — fix your top risks fast.</span>
+        <span class="cta-text">Book Free 30-Minute Review</span>
         <a
           id="sticky-cta-button"
           class="cta-button"


### PR DESCRIPTION
## Summary
- Replace "Next steps" and review sections with one card highlighting the free 30-minute security review
- Refresh navigation and sticky call-to-action text to “Book Free 30-Minute Review”
- Clean up unused guidance styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2197b47e0832889cddfe5ea18f0c8