### PR TITLE
feat: add hover effect to assessment results card

### DIFF
--- a/mini-assessment/index.html
+++ b/mini-assessment/index.html
@@ -358,16 +358,30 @@
         margin-top: 24px;
       }
       .info-block {
-        background: #f9fafb;
-        color: #111;
-        border-radius: 16px;
-        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+        background: var(--surface);
+        color: var(--text);
+        border-radius: 12px;
+        box-shadow: var(--shadow), 0 0 0 var(--stroke-inner) var(--stroke-white) inset;
         padding: 24px 20px;
         margin: 32px 0;
+        transition: box-shadow 0.2s ease;
       }
       .info-block h2 {
         font-size: 20px;
         margin: 0 0 12px;
+      }
+      @media (hover: hover) and (pointer: fine) {
+        .info-block:hover,
+        .info-block:focus {
+          box-shadow: var(--shadow), 0 0 0 var(--glow-size) var(--accent-blue),
+            0 0 0 var(--stroke-inner) var(--stroke-white) inset;
+        }
+      }
+      @media (hover: none) {
+        .info-block:active {
+          box-shadow: var(--shadow), 0 0 0 var(--glow-size) var(--accent-blue),
+            0 0 0 var(--stroke-inner) var(--stroke-white) inset;
+        }
       }
       .bullet-list {
         list-style: disc;
@@ -380,7 +394,7 @@
       }
       .reassurance {
         font-size: 13px;
-        color: #888;
+        color: var(--muted);
         margin-top: 16px;
         padding-left: 20px;
       }


### PR DESCRIPTION
## Summary
- refine results card styles for mini assessment
- add desktop hover and mobile active states to card
- match security review section with dark theme

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b21bbeb5448328b84235f05d917b8c