### PR TITLE
Show footer CTA when improvement section starts

### DIFF
--- a/mini-assessment/app.js
+++ b/mini-assessment/app.js
@@ -74,7 +74,6 @@
   const navCta = document.getElementById("nav-cta");
   const stickyBar = document.getElementById("sticky-cta");
   const stickyCtaBtn = document.getElementById("sticky-cta-button");
-  const scoreBlock = document.getElementById("score-block");
   const assessmentHeading = document.querySelector(".assessment-heading");
   const assessmentNote = document.querySelector(".assessment-note");
   let stickyObserver;
@@ -514,16 +513,16 @@
 
     stickyObserver = new IntersectionObserver((entries) => {
       entries.forEach((entry) => {
-        if (entry.isIntersecting) {
-          stickyBar.classList.remove("show");
-          header.classList.remove("hidden");
-        } else {
+        if (entry.isIntersecting || entry.boundingClientRect.top < 0) {
           stickyBar.classList.add("show");
           header.classList.add("hidden");
+        } else {
+          stickyBar.classList.remove("show");
+          header.classList.remove("hidden");
         }
       });
     });
-    stickyObserver.observe(scoreBlock);
+    stickyObserver.observe(gapsTitleEl);
 
     const track = (loc) => {
       if (window.dataLayer) {


### PR DESCRIPTION
## Summary
- Reveal sticky footer CTA when the "Opportunities for improvement" section comes into view
- Keep header hidden while footer CTA is visible

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2234c1568832880e7467a94793039