### PR TITLE
Improve mini assessment mobile layout

### DIFF
--- a/mini-assessment/index.html
+++ b/mini-assessment/index.html
@@ -27,6 +27,11 @@
         --glow-size: 2px;
         --donut-size: 220px;
       }
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
       body {
         margin: 0;
         min-height: 100vh;
@@ -634,6 +639,24 @@
       .cta-bar .cta-text {
         font-size: 14px;
         white-space: nowrap;
+      }
+      @media (max-width: 480px) {
+        .cta-bar {
+          height: auto;
+        }
+        .cta-inner {
+          flex-direction: column;
+          align-items: center;
+          gap: 8px;
+          padding: 8px 16px;
+        }
+        .cta-bar .cta-text {
+          text-align: center;
+          white-space: normal;
+        }
+        .cta-button {
+          width: 100%;
+        }
       }
       .assessment-heading {
         color: #FF6A3D;


### PR DESCRIPTION
## Summary
- add global `box-sizing: border-box` to prevent width overflow
- stack bottom CTA elements and allow text wrapping on small screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2257e1d2483288ea5f1437a1e9bf8