### PR TITLE
Improve mini assessment results UI

### DIFF
--- a/mini-assessment/config.js
+++ b/mini-assessment/config.js
@@ -49,7 +49,7 @@ window.ASSESSMENT_CONFIG = {
     history: true,
   },
   chart: {
-    size: 160,
+    size: 220,
     thickness: 35,
   },
   ranges: [

--- a/mini-assessment/index.html
+++ b/mini-assessment/index.html
@@ -498,7 +498,7 @@
         }
       }
       .gaps {
-        margin-top: 16px;
+        margin: 32px 0;
       }
       .gap-group + .gap-group {
         margin-top: 16px;
@@ -570,12 +570,11 @@
       .severity-2 .gap-item::before {
         background: var(--color-risk-low);
       }
-      #gaps-title,
       #gaps {
         grid-column: 1 / -1;
       }
       #gaps-title {
-        margin: 48px 0 16px;
+        margin: 0 0 12px;
         padding-bottom: 8px;
         border-bottom: 1px solid #ddd;
         font-size: 18px;
@@ -606,6 +605,9 @@
       }
       #results {
         padding-bottom: 72px;
+      }
+      #results:focus {
+        outline: none;
       }
       .cta-bar {
         position: fixed;
@@ -762,8 +764,9 @@
           </ul>
           <p class="reassurance">No pitch — your results stay private.</p>
         </section>
-        <h4 id="gaps-title" class="fade-line" hidden></h4>
-        <div id="gaps" class="gaps fade-line" hidden></div>
+        <div id="gaps" class="gaps info-block fade-line" hidden>
+          <h4 id="gaps-title" class="fade-line" hidden></h4>
+        </div>
         <button id="restart" type="button" class="fade-line"></button>
       </section>
     </main>


### PR DESCRIPTION
## Summary
- Enlarge mobile severity donut for clearer scoring
- Style Opportunities for Improvement with info-block border and heading adjustments
- Remove stray blue outline on results view

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b22f2b47cc832880c9b1e7ec9fba93