### PR TITLE
Hide navigation bar only after scrolling past results

### DIFF
--- a/mini-assessment/app.js
+++ b/mini-assessment/app.js
@@ -519,7 +519,7 @@
 
     stickyObserver = new IntersectionObserver((entries) => {
       entries.forEach((entry) => {
-        if (entry.isIntersecting || entry.boundingClientRect.top < 0) {
+        if (entry.boundingClientRect.top < 0) {
           stickyBar.classList.add("show");
           header.classList.add("hidden");
         } else {


### PR DESCRIPTION
## Summary
- Refine sticky bar IntersectionObserver so the header hides only once the observed section scrolls past the top of the viewport

## Testing
- `node --check mini-assessment/app.js && echo "Syntax OK"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b25d048de083288a5c40043420f9e2