### PR TITLE
fix: stabilize results header spacing

### DIFF
--- a/mini-assessment/index.html
+++ b/mini-assessment/index.html
@@ -604,8 +604,11 @@
         margin-right: auto;
       }
       #results {
-        padding-bottom: 72px;
+        padding: 32px 0 72px;
         scroll-margin-top: 60px;
+      }
+      #results > *:first-child {
+        margin-top: 0;
       }
       #results:focus {
         outline: none;


### PR DESCRIPTION
## Summary
- add top padding to mini assessment results container
- clear top margin on first card to avoid header gap

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2605fbe40832891e65ca7597c93da