### PR TITLE
Show CTA bar when opportunities section is visible

### DIFF
--- a/mini-assessment/app.js
+++ b/mini-assessment/app.js
@@ -519,7 +519,11 @@
 
     stickyObserver = new IntersectionObserver((entries) => {
       entries.forEach((entry) => {
-        if (entry.boundingClientRect.top < 0) {
+        // Show the sticky bar as soon as the opportunities section enters
+        // the viewport and keep it visible while it remains in view or has
+        // been scrolled past. Hide the bar only when the section has not yet
+        // been reached (i.e., is still below the viewport).
+        if (entry.isIntersecting || entry.boundingClientRect.top < 0) {
           stickyBar.classList.add("show");
           header.classList.add("hidden");
         } else {


### PR DESCRIPTION
## Summary
- reveal sticky CTA bar as soon as the Opportunities for improvement section appears, hiding the header while visible

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b26205eb30832891a51301b9848862