### PR TITLE
fix: improve mobile stability on mini assessment

### DIFF
--- a/mini-assessment/app.js
+++ b/mini-assessment/app.js
@@ -5,6 +5,11 @@
     return;
   }
   const root = document.documentElement;
+  if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
+  if (window.location.hash)
+    history.replaceState(null, '', window.location.pathname + window.location.search);
+  requestAnimationFrame(() => window.scrollTo(0, 0));
+  window.addEventListener('load', () => window.scrollTo(0, 0));
   const brand = Object.assign(
     {
       bg: "#000000",
@@ -255,25 +260,27 @@
     nextBtn.disabled = !sel;
   }
 
-  function showQuestion(idx, opts = {}) {
-    clearTimeout(autoTimer);
-    current = idx;
-    fieldsets.forEach((wrap, i) => {
-      if (i === idx) {
-        wrap.hidden = false;
-        requestAnimationFrame(() => wrap.classList.add("active"));
-      } else {
-        wrap.classList.remove("active");
-        wrap.hidden = true;
-      }
-    });
-    updateProgress();
-    updateNextState();
-    backBtn.disabled = idx === 0;
-    fieldsets[idx].scrollIntoView({ behavior: "smooth", block: "center" });
-    fieldsets[idx].querySelector("fieldset").focus();
+    function showQuestion(idx, opts = {}) {
+      clearTimeout(autoTimer);
+      current = idx;
+      fieldsets.forEach((wrap, i) => {
+        if (i === idx) {
+          wrap.hidden = false;
+          requestAnimationFrame(() => wrap.classList.add("active"));
+        } else {
+          wrap.classList.remove("active");
+          wrap.hidden = true;
+        }
+      });
+      updateProgress();
+      updateNextState();
+      backBtn.disabled = idx === 0;
+      if (!opts.skipScroll)
+        fieldsets[idx].scrollIntoView({ behavior: "smooth", block: "center" });
+      if (!opts.skipFocus)
+        fieldsets[idx].querySelector("fieldset").focus();
 
-    if (useHistory && opts.updateHistory !== false) {
+      if (useHistory && opts.updateHistory !== false) {
       const url = new URL(window.location);
       url.searchParams.set("step", idx + 1);
       if (opts.replace) {
@@ -295,8 +302,8 @@
         startIdx = parsed - 1;
       }
     }
-    showQuestion(startIdx, { replace: true });
-  }
+      showQuestion(startIdx, { replace: true, skipScroll: true, skipFocus: true });
+    }
 
   function renderChart(counts, animate = true) {
     const total = fieldsets.length;

--- a/mini-assessment/index.html
+++ b/mini-assessment/index.html
@@ -19,51 +19,68 @@
       gtag('config', 'G-4HFEY2Y8K7');
     </script>
     <style>
-      :root {
-        line-height: 1.5;
-        --radius-card: 18px;
-        --radius-row: 12px;
-        --stroke-inner: 1px;
-        --glow-size: 2px;
-        --donut-size: 220px;
-      }
+        :root {
+          line-height: 1.5;
+          --radius-card: 18px;
+          --radius-row: 12px;
+          --stroke-inner: 1px;
+          --glow-size: 2px;
+          --donut-size: 220px;
+          --header-height: 60px;
+        }
       *,
       *::before,
       *::after {
         box-sizing: border-box;
       }
-      body {
-        margin: 0;
-        min-height: 100vh;
-        display: flex;
-        flex-direction: column;
-        font-family: system-ui, sans-serif;
-        background: var(--bg);
-        color: var(--text);
-        line-height: 1.5;
-      }
-      .navbar {
-        position: sticky;
-        top: 0;
-        background: var(--header-navy);
-        z-index: 100;
-        transition: box-shadow 0.2s ease, opacity 0.2s ease,
-          transform 0.2s ease;
-        height: 60px;
-      }
+        body {
+          margin: 0;
+          /* fallback for browsers without dynamic viewport units */
+          min-height: 100%;
+          display: flex;
+          flex-direction: column;
+          font-family: system-ui, sans-serif;
+          background: var(--bg);
+          color: var(--text);
+          line-height: 1.5;
+        }
+        @supports (height: 100dvh) {
+          body {
+            min-height: 100dvh;
+          }
+        }
+        .navbar {
+          position: sticky;
+          top: 0;
+          background: var(--header-navy);
+          z-index: 100;
+          transition: box-shadow 0.2s ease, opacity 0.2s ease;
+          padding-top: env(safe-area-inset-top);
+          height: calc(var(--header-height) + env(safe-area-inset-top));
+        }
       .navbar.scrolled {
         box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
       }
-      .navbar.hidden {
-        opacity: 0;
-        transform: translateY(-8px);
-        pointer-events: none;
-      }
-      @media (min-width: 768px) {
-        .navbar {
-          height: 64px;
+        .navbar.hidden {
+          opacity: 0;
+          pointer-events: none;
         }
-      }
+        @media (min-width: 768px) {
+          :root {
+            --header-height: 64px;
+          }
+        }
+        h1,
+        h2,
+        h3,
+        h4,
+        h5,
+        h6 {
+          scroll-margin-top: calc(var(--header-height) + env(safe-area-inset-top));
+        }
+        #results {
+          scroll-margin-top: calc(var(--header-height) + env(safe-area-inset-top));
+        }
       .nav-inner {
         display: flex;
         align-items: center;
@@ -95,25 +112,24 @@
         margin-top: 4px;
         text-align: center;
       }
-      .nav-cta {
-        background: var(--accent-orange);
-        color: #fff;
-        text-decoration: none;
-        padding: 0 16px;
-        border-radius: 999px;
-        font-weight: 600;
-        line-height: 1;
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        height: 40px;
-        transition: opacity 0.2s ease, transform 0.2s ease;
-      }
-      .nav-cta.hidden {
-        opacity: 0;
-        transform: translateY(-8px);
-        pointer-events: none;
-      }
+        .nav-cta {
+          background: var(--accent-orange);
+          color: #fff;
+          text-decoration: none;
+          padding: 0 16px;
+          border-radius: 999px;
+          font-weight: 600;
+          line-height: 1;
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          height: 40px;
+          transition: opacity 0.2s ease;
+        }
+        .nav-cta.hidden {
+          opacity: 0;
+          pointer-events: none;
+        }
       .container {
         flex: 1;
         width: 100%;
@@ -664,11 +680,15 @@
           width: 100%;
         }
       }
-      .assessment-heading {
-        color: #FF6A3D;
-        text-align: center;
-        margin: 24px 0;
-      }
+        .assessment-heading {
+          color: #FF6A3D;
+          text-align: center;
+          margin: 24px auto;
+          line-height: 1.2;
+          max-width: 25ch;
+          font-size: clamp(1.5rem, 6vw, 2.5rem);
+          text-wrap: balance;
+        }
       .assessment-note {
         color: #ffffff;
         text-align: center;


### PR DESCRIPTION
## Summary
- disable scroll restoration, hash navigation and auto scroll/focus on initial load
- switch to dynamic viewport units and add safe-area offsets with sticky header
- make heading responsive and add scroll offsets for anchors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2650cb1308328a8e12155bb04f611