### PR TITLE
Center risk score donut on desktop

### DIFF
--- a/mini-assessment/index.html
+++ b/mini-assessment/index.html
@@ -466,14 +466,20 @@
       }
       @media (min-width: 768px) {
         #severity-chart {
-          flex-direction: row;
+          position: relative;
+          width: var(--donut-size);
+          flex-direction: column;
         }
         .severity-legend {
+          position: absolute;
+          top: 50%;
+          left: calc(100% + 24px);
+          transform: translateY(-50%);
           display: flex;
           flex-direction: column;
           align-items: flex-start;
-          margin: 0 0 0 24px;
           gap: 8px;
+          margin: 0;
         }
       }
       @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
- Center the mini assessment donut and heading on desktop view by constraining the chart area and positioning the legend beside it.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b274dacac883289b7c6b1a43add2a6