### PR TITLE
Fix scoring layout on mini assessment results page

### DIFF
--- a/mini-assessment/index.html
+++ b/mini-assessment/index.html
@@ -493,15 +493,16 @@
       }
       @media (min-width: 768px) {
         #severity-chart {
-          position: relative;
-          width: var(--donut-size);
-          flex-direction: column;
+          display: flex;
+          flex-direction: row;
+          align-items: center;
+          justify-content: center;
+          gap: 24px;
+          width: auto;
         }
         .severity-legend {
-          position: absolute;
-          top: 50%;
-          left: calc(100% + 24px);
-          transform: translateY(-50%);
+          position: static;
+          transform: none;
           display: flex;
           flex-direction: column;
           align-items: flex-start;


### PR DESCRIPTION
## Summary
- align severity chart and legend on desktop using flex layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b277c94fac8328a282cb4d5d7f12db