### PR TITLE
Add tabbed QR code type builder

### DIFF
--- a/tools/index.html
+++ b/tools/index.html
@@ -1,0 +1,230 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Vectari Tools | Useful Security Utilities</title>
+  <meta name="description" content="Vectari tools provide helpful cybersecurity utilities including QR code generation and more coming soon.">
+  <link rel="icon" type="image/png" href="/static/assets/logo.png">
+  <style>
+    :root {
+      --color-navy: #00172C;
+      --color-blue: #0076d1;
+      --color-teal: #10B5A6;
+      --color-orange: #FF6A3D;
+      --color-light: #f5f7fa;
+      --font-family: 'Inter', sans-serif;
+    }
+    * {
+      box-sizing: border-box;
+    }
+    body {
+      margin: 0;
+      font-family: var(--font-family);
+      background: radial-gradient(circle at top right, rgba(16, 181, 166, 0.25), transparent 55%),
+                  radial-gradient(circle at bottom left, rgba(0, 118, 209, 0.25), transparent 60%),
+                  #000;
+      color: #fff;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+    header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 1rem 1.5rem;
+      max-width: 1100px;
+      margin: 0 auto;
+      width: 100%;
+    }
+    header a {
+      color: #fff;
+      text-decoration: none;
+      font-weight: 600;
+      font-size: 0.95rem;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      opacity: 0.85;
+    }
+    header a:hover {
+      opacity: 1;
+    }
+    .logo {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      font-weight: 700;
+      letter-spacing: 0.03em;
+    }
+    .logo img {
+      height: 42px;
+      width: auto;
+    }
+    main {
+      flex: 1;
+      width: 100%;
+    }
+    .hero {
+      text-align: center;
+      padding: 3rem 1.5rem 2rem;
+    }
+    .hero h1 {
+      font-size: clamp(2.5rem, 5vw, 3.5rem);
+      margin-bottom: 0.75rem;
+    }
+    .hero p {
+      margin: 0;
+      font-size: 1rem;
+      color: rgba(255, 255, 255, 0.85);
+      max-width: 600px;
+      margin-inline: auto;
+    }
+    .tool-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 1.5rem;
+      padding: 2.5rem 1.5rem 4rem;
+      max-width: 1100px;
+      margin: 0 auto;
+    }
+    .tool-card {
+      background: rgba(1, 12, 31, 0.7);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 18px;
+      padding: 1.75rem 1.5rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+      transition: transform 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease;
+      text-decoration: none;
+      color: inherit;
+      position: relative;
+      overflow: hidden;
+    }
+    .tool-card::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      background: linear-gradient(135deg, rgba(16, 181, 166, 0.15), rgba(255, 106, 61, 0.15));
+      opacity: 0;
+      transition: opacity 0.25s ease;
+      pointer-events: none;
+    }
+    .tool-card:hover {
+      transform: translateY(-6px);
+      border-color: rgba(255, 255, 255, 0.25);
+      box-shadow: 0 18px 32px rgba(0, 0, 0, 0.35);
+    }
+    .tool-card:hover::after {
+      opacity: 1;
+    }
+    .tool-icon {
+      height: 64px;
+      width: 64px;
+      border-radius: 18px;
+      background: rgba(255, 255, 255, 0.1);
+      display: grid;
+      place-items: center;
+    }
+    .tool-title {
+      font-size: 1.25rem;
+      font-weight: 600;
+      margin: 0;
+    }
+    .tool-description {
+      margin: 0;
+      line-height: 1.5;
+      color: rgba(255, 255, 255, 0.75);
+      font-size: 0.95rem;
+    }
+    .tool-meta {
+      margin-top: auto;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      font-size: 0.85rem;
+      color: rgba(255, 255, 255, 0.6);
+    }
+    .tool-meta span {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+    }
+    footer {
+      text-align: center;
+      padding: 2rem 1.5rem 3rem;
+      color: rgba(255, 255, 255, 0.55);
+      font-size: 0.85rem;
+    }
+    @media (max-width: 600px) {
+      header {
+        flex-direction: column;
+        gap: 1rem;
+      }
+      header .logo {
+        flex-direction: column;
+        text-align: center;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <a href="/" class="logo" aria-label="Vectari Home">
+      <img src="/static/assets/logo-bar.png" alt="Vectari logo">
+      <span>Vectari Tools</span>
+    </a>
+    <a href="/">Back to vectari.co</a>
+  </header>
+  <main>
+    <section class="hero">
+      <h1>Tools &amp; Utilities</h1>
+      <p>Explore practical tools created by the Vectari team to support secure operations, simplify compliance, and empower your organization.</p>
+    </section>
+    <section class="tool-grid" aria-label="Tool directory">
+      <a class="tool-card" href="/tools/qr-generator/">
+        <div class="tool-icon" aria-hidden="true">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="40" height="40" fill="none">
+            <rect x="6" y="6" width="20" height="20" rx="3" stroke="#10B5A6" stroke-width="3"/>
+            <rect x="38" y="6" width="20" height="20" rx="3" stroke="#FF6A3D" stroke-width="3"/>
+            <rect x="6" y="38" width="20" height="20" rx="3" stroke="#0076d1" stroke-width="3"/>
+            <rect x="44" y="44" width="14" height="14" rx="3" fill="#fff" opacity="0.2"/>
+            <rect x="30" y="30" width="10" height="10" rx="2" fill="#fff" opacity="0.35"/>
+          </svg>
+        </div>
+        <h2 class="tool-title">QR Code Generator</h2>
+        <p class="tool-description">Create QR codes instantly for URLs, contact details, or any text. Customize colors, size, and download print-ready images.</p>
+        <div class="tool-meta">
+          <span>Launch tool</span>
+          <span>Updated 2024</span>
+        </div>
+      </a>
+      <div class="tool-card" aria-disabled="true" role="article">
+        <div class="tool-icon" aria-hidden="true">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="40" height="40" fill="none">
+            <path d="M16 22h32" stroke="#10B5A6" stroke-width="3" stroke-linecap="round"/>
+            <path d="M16 32h32" stroke="#FF6A3D" stroke-width="3" stroke-linecap="round"/>
+            <path d="M16 42h32" stroke="#0076d1" stroke-width="3" stroke-linecap="round"/>
+            <rect x="20" y="12" width="24" height="40" rx="6" stroke="#fff" opacity="0.25" stroke-width="3"/>
+          </svg>
+        </div>
+        <h2 class="tool-title">More tools coming soon</h2>
+        <p class="tool-description">We are building additional assessment, compliance, and security automation utilities. Check back soon or reach out to request a feature.</p>
+        <div class="tool-meta">
+          <span>Stay tuned</span>
+          <span>In development</span>
+        </div>
+      </div>
+    </section>
+  </main>
+  <footer>
+    &copy; <span id="year"></span> Vectari. All rights reserved.
+  </footer>
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/tools/qr-generator/index.html
+++ b/tools/qr-generator/index.html
@@ -1,0 +1,920 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Vectari QR Code Generator | Create Custom QR Codes</title>
+  <meta name="description" content="Generate high-quality QR codes for URLs, text, or contact information. Customize colors, size, error correction, and download ready-to-share images.">
+  <link rel="icon" type="image/png" href="/static/assets/logo.png">
+  <style>
+    :root {
+      --color-navy: #00172C;
+      --color-blue: #0076d1;
+      --color-teal: #10B5A6;
+      --color-orange: #FF6A3D;
+      --font-family: 'Inter', sans-serif;
+    }
+    * {
+      box-sizing: border-box;
+    }
+    body {
+      margin: 0;
+      font-family: var(--font-family);
+      color: #f5f7fa;
+      background: radial-gradient(circle at top, rgba(0, 118, 209, 0.35), transparent 60%),
+                  radial-gradient(circle at bottom right, rgba(255, 106, 61, 0.25), transparent 60%),
+                  #000;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+    header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 1rem 1.5rem;
+      max-width: 1100px;
+      width: 100%;
+      margin: 0 auto;
+    }
+    header a {
+      color: #fff;
+      text-decoration: none;
+      font-weight: 600;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      opacity: 0.85;
+    }
+    header a:hover {
+      opacity: 1;
+    }
+    .logo img {
+      height: 42px;
+      width: auto;
+    }
+    main {
+      flex: 1;
+      width: 100%;
+      padding: 1rem 1.5rem 3rem;
+    }
+    .layout {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 2rem;
+      max-width: 1100px;
+      margin: 0 auto;
+    }
+    .intro {
+      grid-column: 1 / -1;
+      text-align: center;
+      margin-bottom: 1.5rem;
+    }
+    .intro h1 {
+      margin-bottom: 0.5rem;
+      font-size: clamp(2.25rem, 5vw, 3.25rem);
+    }
+    .intro p {
+      margin: 0;
+      color: rgba(255, 255, 255, 0.8);
+      max-width: 680px;
+      margin-inline: auto;
+      line-height: 1.6;
+    }
+    .panel {
+      background: rgba(1, 12, 31, 0.75);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 20px;
+      padding: 1.75rem;
+      box-shadow: 0 18px 32px rgba(0, 0, 0, 0.35);
+      backdrop-filter: blur(8px);
+    }
+    .panel h2 {
+      margin-top: 0;
+      margin-bottom: 1rem;
+      font-size: 1.25rem;
+    }
+    label {
+      display: block;
+      font-size: 0.9rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: rgba(255, 255, 255, 0.7);
+      margin-bottom: 0.4rem;
+    }
+    input[type="text"], textarea, select, input[type="number"] {
+      width: 100%;
+      padding: 0.75rem 0.9rem;
+      border-radius: 12px;
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      background: rgba(0, 0, 0, 0.35);
+      color: #fff;
+      font-size: 0.95rem;
+      font-family: inherit;
+      transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    }
+    textarea {
+      min-height: 120px;
+      resize: vertical;
+    }
+    input[type="text"]:focus, textarea:focus, select:focus, input[type="number"]:focus {
+      outline: none;
+      border-color: var(--color-teal);
+      box-shadow: 0 0 0 3px rgba(16, 181, 166, 0.25);
+    }
+    .controls {
+      display: grid;
+      gap: 1.25rem;
+    }
+    .type-selector {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+      gap: 0.5rem;
+      background: rgba(0, 0, 0, 0.25);
+      padding: 0.5rem;
+      border-radius: 14px;
+      border: 1px solid rgba(255, 255, 255, 0.08);
+    }
+    .type-selector button {
+      background: transparent;
+      border: 1px solid transparent;
+      color: rgba(255, 255, 255, 0.75);
+      padding: 0.65rem 0.75rem;
+      border-radius: 10px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+    }
+    .type-selector button[aria-selected="true"] {
+      background: rgba(16, 181, 166, 0.18);
+      border-color: rgba(16, 181, 166, 0.6);
+      color: #fff;
+      box-shadow: inset 0 0 0 1px rgba(16, 181, 166, 0.4);
+    }
+    .type-selector button:hover {
+      color: #fff;
+    }
+    .type-panels {
+      background: rgba(0, 0, 0, 0.2);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 14px;
+      padding: 1rem;
+    }
+    .type-fields {
+      display: none;
+      gap: 1rem;
+    }
+    .type-fields.active {
+      display: grid;
+    }
+    .type-fields .inline-controls {
+      margin-top: 0;
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    }
+    .help-text {
+      margin-top: -0.3rem;
+      font-size: 0.8rem;
+      color: rgba(255, 255, 255, 0.55);
+    }
+    .checkbox-field {
+      display: flex;
+      align-items: center;
+      gap: 0.6rem;
+      font-size: 0.85rem;
+      color: rgba(255, 255, 255, 0.75);
+    }
+    .checkbox-field input[type="checkbox"] {
+      width: 18px;
+      height: 18px;
+      accent-color: var(--color-teal);
+    }
+    .inline-controls {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      gap: 1rem;
+    }
+    .color-input {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      padding: 0.5rem 0.75rem;
+      border-radius: 12px;
+      border: 1px solid rgba(255, 255, 255, 0.15);
+      background: rgba(0, 0, 0, 0.25);
+    }
+    .color-input input[type="color"] {
+      border: none;
+      background: transparent;
+      width: 42px;
+      height: 42px;
+      padding: 0;
+      cursor: pointer;
+    }
+    .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+      margin-top: 1.5rem;
+    }
+    button {
+      font-family: inherit;
+      font-weight: 600;
+      border-radius: 999px;
+      padding: 0.75rem 1.5rem;
+      border: none;
+      cursor: pointer;
+      font-size: 0.95rem;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+    }
+    button.primary {
+      background: linear-gradient(135deg, var(--color-orange), var(--color-teal));
+      color: #fff;
+      box-shadow: 0 12px 25px rgba(16, 181, 166, 0.35);
+    }
+    button.secondary {
+      background: rgba(255, 255, 255, 0.1);
+      color: #fff;
+      border: 1px solid rgba(255, 255, 255, 0.15);
+    }
+    button:disabled {
+      opacity: 0.55;
+      cursor: not-allowed;
+      box-shadow: none;
+      transform: none;
+    }
+    button:not(:disabled):hover {
+      transform: translateY(-2px);
+    }
+    .preview-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 1.5rem;
+      text-align: center;
+    }
+    .preview-canvas {
+      padding: 1rem;
+      background: rgba(0, 0, 0, 0.2);
+      border-radius: 16px;
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      display: inline-flex;
+    }
+    canvas {
+      width: 100%;
+      height: auto;
+      max-width: min(360px, 100%);
+    }
+    .preview-details {
+      font-size: 0.9rem;
+      color: rgba(255, 255, 255, 0.7);
+      line-height: 1.5;
+    }
+    .status {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      font-size: 0.85rem;
+      color: rgba(255, 255, 255, 0.65);
+    }
+    .status.success {
+      color: #7DFFCB;
+    }
+    .status.error {
+      color: #ff9b7d;
+    }
+    footer {
+      text-align: center;
+      padding: 2rem 1.5rem 3rem;
+      color: rgba(255, 255, 255, 0.55);
+      font-size: 0.85rem;
+    }
+    @media (max-width: 900px) {
+      .layout {
+        grid-template-columns: 1fr;
+      }
+      .preview-wrapper {
+        order: -1;
+      }
+    }
+    @media (max-width: 600px) {
+      header {
+        flex-direction: column;
+        gap: 1rem;
+      }
+      header .logo {
+        flex-direction: column;
+        text-align: center;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <a href="/tools/" class="logo" aria-label="Vectari Tools">
+      <img src="/static/assets/logo-bar.png" alt="Vectari logo">
+      <span>Vectari Tools</span>
+    </a>
+    <a href="/">Back to vectari.co</a>
+  </header>
+  <main>
+    <div class="layout">
+      <div class="intro">
+        <h1>QR Code Generator</h1>
+        <p>Generate crisp, trackable QR codes for campaigns, signage, and secure workflows. Customize colors, size, and error correction, then download a ready-to-use image.</p>
+      </div>
+      <section class="panel" aria-labelledby="qr-preview">
+        <h2 id="qr-preview">Preview</h2>
+        <div class="preview-wrapper">
+          <div class="preview-canvas" id="previewCanvas">
+            <canvas id="qrCanvas" role="img" aria-label="QR code preview"></canvas>
+          </div>
+          <div class="preview-details" id="previewDetails"></div>
+          <div class="status" id="statusMessage" role="status" aria-live="polite"></div>
+        </div>
+      </section>
+      <section class="panel" aria-labelledby="qr-settings">
+        <h2 id="qr-settings">Configuration</h2>
+        <form class="controls" id="qrForm">
+          <div>
+            <label id="qrTypeLabel">QR code type</label>
+            <div class="type-selector" role="tablist" aria-labelledby="qrTypeLabel">
+              <button type="button" role="tab" id="tab-url" data-type-tab="url" aria-controls="panel-url" aria-selected="true">URL</button>
+              <button type="button" role="tab" id="tab-text" data-type-tab="text" aria-controls="panel-text" aria-selected="false">Text</button>
+              <button type="button" role="tab" id="tab-email" data-type-tab="email" aria-controls="panel-email" aria-selected="false">Email</button>
+              <button type="button" role="tab" id="tab-phone" data-type-tab="phone" aria-controls="panel-phone" aria-selected="false">Phone</button>
+              <button type="button" role="tab" id="tab-sms" data-type-tab="sms" aria-controls="panel-sms" aria-selected="false">SMS</button>
+              <button type="button" role="tab" id="tab-wifi" data-type-tab="wifi" aria-controls="panel-wifi" aria-selected="false">Wi-Fi</button>
+              <button type="button" role="tab" id="tab-contact" data-type-tab="contact" aria-controls="panel-contact" aria-selected="false">Contact</button>
+            </div>
+          </div>
+          <div class="type-panels">
+            <div class="type-fields active" id="panel-url" data-type-panel="url" role="tabpanel" aria-labelledby="tab-url">
+              <div>
+                <label for="urlValue">Destination URL</label>
+                <input type="text" id="urlValue" name="urlValue" placeholder="https://vectari.co/" value="https://vectari.co/" autocomplete="off">
+                <p class="help-text">Paste any web address, UTM link, or landing page.</p>
+              </div>
+            </div>
+            <div class="type-fields" id="panel-text" data-type-panel="text" role="tabpanel" aria-labelledby="tab-text">
+              <div>
+                <label for="textValue">Plain text</label>
+                <textarea id="textValue" name="textValue" placeholder="Type the message you want to encode." rows="4">Scan to connect with Vectari.</textarea>
+              </div>
+            </div>
+            <div class="type-fields" id="panel-email" data-type-panel="email" role="tabpanel" aria-labelledby="tab-email">
+              <div>
+                <label for="emailAddress">Recipient email</label>
+                <input type="email" id="emailAddress" name="emailAddress" placeholder="team@vectari.co" autocomplete="email">
+              </div>
+              <div>
+                <label for="emailSubject">Subject</label>
+                <input type="text" id="emailSubject" name="emailSubject" placeholder="Quick introduction">
+              </div>
+              <div>
+                <label for="emailBody">Message</label>
+                <textarea id="emailBody" name="emailBody" rows="3" placeholder="Hello from Vectari!"></textarea>
+              </div>
+            </div>
+            <div class="type-fields" id="panel-phone" data-type-panel="phone" role="tabpanel" aria-labelledby="tab-phone">
+              <div>
+                <label for="phoneNumber">Phone number</label>
+                <input type="tel" id="phoneNumber" name="phoneNumber" placeholder="+1 800 555 1212" autocomplete="tel">
+                <p class="help-text">When scanned, the phone will prompt to call this number.</p>
+              </div>
+            </div>
+            <div class="type-fields" id="panel-sms" data-type-panel="sms" role="tabpanel" aria-labelledby="tab-sms">
+              <div>
+                <label for="smsNumber">Recipient number</label>
+                <input type="tel" id="smsNumber" name="smsNumber" placeholder="+1 800 555 1212" autocomplete="tel">
+              </div>
+              <div>
+                <label for="smsMessage">SMS message</label>
+                <textarea id="smsMessage" name="smsMessage" rows="3" placeholder="Ready to talk security?"></textarea>
+              </div>
+            </div>
+            <div class="type-fields" id="panel-wifi" data-type-panel="wifi" role="tabpanel" aria-labelledby="tab-wifi">
+              <div>
+                <label for="wifiSsid">Network name (SSID)</label>
+                <input type="text" id="wifiSsid" name="wifiSsid" placeholder="Vectari Guest">
+              </div>
+              <div class="inline-controls">
+                <div>
+                  <label for="wifiEncryption">Security</label>
+                  <select id="wifiEncryption" name="wifiEncryption">
+                    <option value="WPA" selected>WPA/WPA2</option>
+                    <option value="WEP">WEP</option>
+                    <option value="nopass">None</option>
+                  </select>
+                </div>
+                <div>
+                  <label for="wifiPassword">Password</label>
+                  <input type="text" id="wifiPassword" name="wifiPassword" placeholder="Required for secured networks">
+                </div>
+              </div>
+              <label class="checkbox-field" for="wifiHidden">
+                <input type="checkbox" id="wifiHidden" name="wifiHidden">
+                Hidden network
+              </label>
+            </div>
+            <div class="type-fields" id="panel-contact" data-type-panel="contact" role="tabpanel" aria-labelledby="tab-contact">
+              <div class="inline-controls">
+                <div>
+                  <label for="contactFirst">First name</label>
+                  <input type="text" id="contactFirst" name="contactFirst" placeholder="Alex" autocomplete="given-name">
+                </div>
+                <div>
+                  <label for="contactLast">Last name</label>
+                  <input type="text" id="contactLast" name="contactLast" placeholder="Rivera" autocomplete="family-name">
+                </div>
+              </div>
+              <div>
+                <label for="contactCompany">Company</label>
+                <input type="text" id="contactCompany" name="contactCompany" placeholder="Vectari" autocomplete="organization">
+              </div>
+              <div class="inline-controls">
+                <div>
+                  <label for="contactPhone">Phone</label>
+                  <input type="tel" id="contactPhone" name="contactPhone" placeholder="+1 800 555 1212" autocomplete="tel">
+                </div>
+                <div>
+                  <label for="contactEmail">Email</label>
+                  <input type="email" id="contactEmail" name="contactEmail" placeholder="team@vectari.co" autocomplete="email">
+                </div>
+              </div>
+              <div>
+                <label for="contactWebsite">Website</label>
+                <input type="url" id="contactWebsite" name="contactWebsite" placeholder="https://vectari.co/" autocomplete="url">
+              </div>
+            </div>
+          </div>
+          <input type="hidden" id="qrText" name="qrText" value="https://vectari.co/">
+          <div class="inline-controls">
+            <div>
+              <label for="qrSize">Size (px)</label>
+              <input type="number" id="qrSize" name="qrSize" min="120" max="1024" step="10" value="320">
+            </div>
+            <div>
+              <label for="qrMargin">Quiet zone (px)</label>
+              <input type="number" id="qrMargin" name="qrMargin" min="0" max="32" value="4">
+            </div>
+            <div>
+              <label for="qrCorrection">Error correction</label>
+              <select id="qrCorrection" name="qrCorrection">
+                <option value="L">Low (L)</option>
+                <option value="M">Medium (M)</option>
+                <option value="Q" selected>Quartile (Q)</option>
+                <option value="H">High (H)</option>
+              </select>
+            </div>
+          </div>
+          <div class="inline-controls">
+            <div>
+              <label for="qrForeground">Foreground</label>
+              <div class="color-input">
+                <input type="color" id="qrForeground" name="qrForeground" value="#0bcebc" aria-label="Foreground color">
+                <input type="text" id="qrForegroundHex" value="#0BCEBC" maxlength="7" aria-label="Foreground hex code">
+              </div>
+            </div>
+            <div>
+              <label for="qrBackground">Background</label>
+              <div class="color-input">
+                <input type="color" id="qrBackground" name="qrBackground" value="#00172C" aria-label="Background color">
+                <input type="text" id="qrBackgroundHex" value="#00172C" maxlength="7" aria-label="Background hex code">
+              </div>
+            </div>
+          </div>
+          <div class="actions">
+            <button type="submit" class="primary">Generate QR Code</button>
+            <button type="button" class="secondary" id="downloadBtn" disabled>Download PNG</button>
+            <button type="button" class="secondary" id="copyBtn" disabled>Copy Image</button>
+          </div>
+        </form>
+      </section>
+    </div>
+  </main>
+  <footer>
+    &copy; <span id="year"></span> Vectari. All rights reserved.
+  </footer>
+  <script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.3/build/qrcode.min.js" integrity="sha256-7AV/QXpVZl8vGeOawx2UY8ailqXF/w3vGN9VOGBev5I=" crossorigin="anonymous"></script>
+  <script>
+    const form = document.getElementById('qrForm');
+    const textInput = document.getElementById('qrText');
+    const sizeInput = document.getElementById('qrSize');
+    const marginInput = document.getElementById('qrMargin');
+    const correctionInput = document.getElementById('qrCorrection');
+    const fgPicker = document.getElementById('qrForeground');
+    const bgPicker = document.getElementById('qrBackground');
+    const fgHex = document.getElementById('qrForegroundHex');
+    const bgHex = document.getElementById('qrBackgroundHex');
+    const canvas = document.getElementById('qrCanvas');
+    const previewDetails = document.getElementById('previewDetails');
+    const statusMessage = document.getElementById('statusMessage');
+    const downloadBtn = document.getElementById('downloadBtn');
+    const copyBtn = document.getElementById('copyBtn');
+    const previewFrame = document.getElementById('previewCanvas');
+    const typeTabs = document.querySelectorAll('[data-type-tab]');
+    const typePanels = document.querySelectorAll('[data-type-panel]');
+    const tabList = Array.from(typeTabs);
+    const urlValue = document.getElementById('urlValue');
+    const textValue = document.getElementById('textValue');
+    const emailAddress = document.getElementById('emailAddress');
+    const emailSubject = document.getElementById('emailSubject');
+    const emailBody = document.getElementById('emailBody');
+    const phoneNumber = document.getElementById('phoneNumber');
+    const smsNumber = document.getElementById('smsNumber');
+    const smsMessage = document.getElementById('smsMessage');
+    const wifiSsid = document.getElementById('wifiSsid');
+    const wifiEncryption = document.getElementById('wifiEncryption');
+    const wifiPassword = document.getElementById('wifiPassword');
+    const wifiHidden = document.getElementById('wifiHidden');
+    const contactFirst = document.getElementById('contactFirst');
+    const contactLast = document.getElementById('contactLast');
+    const contactCompany = document.getElementById('contactCompany');
+    const contactPhone = document.getElementById('contactPhone');
+    const contactEmail = document.getElementById('contactEmail');
+    const contactWebsite = document.getElementById('contactWebsite');
+
+    let currentType = document.querySelector('[data-type-panel].active')?.dataset.typePanel || 'url';
+
+    typeTabs.forEach((tab) => {
+      const isActive = tab.dataset.typeTab === currentType;
+      tab.setAttribute('aria-selected', isActive ? 'true' : 'false');
+      tab.tabIndex = isActive ? 0 : -1;
+    });
+
+    typePanels.forEach((panel) => {
+      const isActive = panel.classList.contains('active');
+      panel.hidden = !isActive;
+      panel.setAttribute('aria-hidden', (!isActive).toString());
+    });
+
+    let latestDataURL = '';
+    const correctionLevels = {
+      L: 'low',
+      M: 'medium',
+      Q: 'quartile',
+      H: 'high'
+    };
+
+    function truncate(value, length = 42) {
+      if (!value) return '';
+      return value.length > length ? `${value.slice(0, length - 1)}…` : value;
+    }
+
+    function escapeHTML(value) {
+      if (!value) return '';
+      const map = {
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;'
+      };
+      map['"'] = '&quot;';
+      map["'"] = '&#39;';
+      return value.replace(/[&<>"']/g, (char) => map[char]);
+    }
+
+    function normalizePhone(value) {
+      return value.replace(/[^+\d]/g, '');
+    }
+
+    function escapeWifi(value) {
+      return (value || '').replace(/([\\;,:"])/g, '\\$1');
+    }
+
+    function escapeVCard(value) {
+      return (value || '').replace(/\\/g, '\\\\').replace(/\n/g, '\\n').replace(/,/g, '\\,').replace(/;/g, '\\;');
+    }
+
+    const wifiSecurityLabels = {
+      WPA: 'WPA/WPA2',
+      WEP: 'WEP',
+      nopass: 'Open'
+    };
+
+    const typeBuilders = {
+      url: () => {
+        const raw = urlValue.value.trim();
+        if (!raw) {
+          return { error: 'Enter a destination URL to encode.' };
+        }
+        const hasScheme = /^[a-z][\w+.-]*:/i.test(raw);
+        const prefixed = hasScheme || raw.startsWith('//') ? raw : `https://${raw}`;
+        return {
+          payload: prefixed,
+          summary: `URL → ${truncate(prefixed)}`
+        };
+      },
+      text: () => {
+        const raw = textValue.value.trim();
+        if (!raw) {
+          return { error: 'Add the text you want to encode.' };
+        }
+        return {
+          payload: raw,
+          summary: `Text message (${raw.length} characters)`
+        };
+      },
+      email: () => {
+        const address = emailAddress.value.trim();
+        if (!address) {
+          return { error: 'Provide the email address to reach.' };
+        }
+        const params = new URLSearchParams();
+        if (emailSubject.value.trim()) {
+          params.append('subject', emailSubject.value.trim());
+        }
+        if (emailBody.value.trim()) {
+          params.append('body', emailBody.value.trim());
+        }
+        const query = params.toString();
+        return {
+          payload: `mailto:${address}${query ? `?${query}` : ''}`,
+          summary: `Email link to ${address}`
+        };
+      },
+      phone: () => {
+        const number = normalizePhone(phoneNumber.value.trim());
+        if (!number) {
+          return { error: 'Add the phone number to dial.' };
+        }
+        return {
+          payload: `tel:${number}`,
+          summary: `Phone call to ${number}`
+        };
+      },
+      sms: () => {
+        const number = normalizePhone(smsNumber.value.trim());
+        if (!number) {
+          return { error: 'Add the SMS recipient number.' };
+        }
+        const params = new URLSearchParams();
+        if (smsMessage.value.trim()) {
+          params.append('body', smsMessage.value.trim());
+        }
+        const query = params.toString();
+        return {
+          payload: `sms:${number}${query ? `?${query}` : ''}`,
+          summary: `SMS to ${number}${smsMessage.value.trim() ? ' with preset message' : ''}`
+        };
+      },
+      wifi: () => {
+        const ssid = wifiSsid.value.trim();
+        const security = wifiEncryption.value;
+        const password = wifiPassword.value.trim();
+        if (!ssid) {
+          return { error: 'Enter the Wi-Fi network name (SSID).' };
+        }
+        if (security !== 'nopass' && !password) {
+          return { error: 'Add the Wi-Fi password or switch security to None.' };
+        }
+        const escapedSsid = escapeWifi(ssid);
+        const escapedPassword = escapeWifi(password);
+        const hidden = wifiHidden.checked ? 'true' : 'false';
+        const payloadParts = [`WIFI:T:${security};S:${escapedSsid};`];
+        if (security !== 'nopass') {
+          payloadParts.push(`P:${escapedPassword};`);
+        }
+        payloadParts.push(`H:${hidden};`);
+        payloadParts.push(';');
+        return {
+          payload: payloadParts.join(''),
+          summary: `Wi-Fi network "${truncate(ssid, 26)}" (${wifiSecurityLabels[security] || security})`
+        };
+      },
+      contact: () => {
+        const first = contactFirst.value.trim();
+        const last = contactLast.value.trim();
+        const company = contactCompany.value.trim();
+        const phone = contactPhone.value.trim();
+        const email = contactEmail.value.trim();
+        const website = contactWebsite.value.trim();
+        if (!first && !last && !company) {
+          return { error: 'Add a name or company for the contact card.' };
+        }
+        const lines = ['BEGIN:VCARD', 'VERSION:3.0'];
+        lines.push(`N:${escapeVCard(last)};${escapeVCard(first)};;;`);
+        const fullName = `${first} ${last}`.trim();
+        const displayName = fullName || company;
+        lines.push(`FN:${escapeVCard(displayName)}`);
+        if (company) {
+          lines.push(`ORG:${escapeVCard(company)}`);
+        }
+        if (phone) {
+          lines.push(`TEL;TYPE=CELL:${escapeVCard(phone)}`);
+        }
+        if (email) {
+          lines.push(`EMAIL:${escapeVCard(email)}`);
+        }
+        if (website) {
+          lines.push(`URL:${escapeVCard(website)}`);
+        }
+        lines.push('END:VCARD');
+        return {
+          payload: lines.join('\n'),
+          summary: displayName ? `Contact card for ${truncate(displayName, 32)}` : 'Contact card'
+        };
+      }
+    };
+
+    function getPayloadForCurrentType() {
+      const builder = typeBuilders[currentType];
+      if (!builder) {
+        return { payload: textInput.value, summary: '' };
+      }
+      return builder();
+    }
+
+    function setActiveType(type) {
+      if (currentType === type) return;
+      currentType = type;
+      typeTabs.forEach((tab) => {
+        const isActive = tab.dataset.typeTab === type;
+        tab.setAttribute('aria-selected', isActive ? 'true' : 'false');
+        tab.tabIndex = isActive ? 0 : -1;
+      });
+      typePanels.forEach((panel) => {
+        const isActive = panel.dataset.typePanel === type;
+        panel.classList.toggle('active', isActive);
+        panel.hidden = !isActive;
+        panel.setAttribute('aria-hidden', (!isActive).toString());
+      });
+      showStatus('', 'info');
+      generateQRCode();
+    }
+
+    function syncHexInputs() {
+      fgHex.value = fgPicker.value.toUpperCase();
+      bgHex.value = bgPicker.value.toUpperCase();
+    }
+
+    function parseHex(value, fallback) {
+      const normalized = value.trim().replace(/^#?/, '#');
+      const hexRegex = /^#([0-9a-fA-F]{6})$/;
+      return hexRegex.test(normalized) ? normalized.toUpperCase() : fallback;
+    }
+
+    function showStatus(message, type = 'info') {
+      statusMessage.textContent = message;
+      statusMessage.className = `status ${type}`;
+      if (message) {
+        statusMessage.setAttribute('aria-hidden', 'false');
+      } else {
+        statusMessage.setAttribute('aria-hidden', 'true');
+      }
+    }
+
+    async function generateQRCode(event) {
+      if (event) {
+        event.preventDefault();
+      }
+      const { payload, summary, error } = getPayloadForCurrentType();
+      if (error) {
+        showStatus(error, 'error');
+        downloadBtn.disabled = true;
+        copyBtn.disabled = true;
+        latestDataURL = '';
+        previewDetails.textContent = '';
+        return;
+      }
+      const value = payload.trim();
+      if (!value) {
+        showStatus('Enter content to encode.', 'error');
+        downloadBtn.disabled = true;
+        copyBtn.disabled = true;
+        latestDataURL = '';
+        previewDetails.textContent = '';
+        return;
+      }
+      textInput.value = value;
+      const size = Math.min(Math.max(parseInt(sizeInput.value, 10) || 320, 120), 1024);
+      const margin = Math.min(Math.max(parseInt(marginInput.value, 10) || 4, 0), 32);
+      const correction = correctionInput.value;
+      const fgColor = parseHex(fgHex.value, fgPicker.value);
+      const bgColor = parseHex(bgHex.value, bgPicker.value);
+
+      fgPicker.value = fgColor;
+      bgPicker.value = bgColor;
+      fgHex.value = fgColor;
+      bgHex.value = bgColor;
+
+      try {
+        await QRCode.toCanvas(canvas, value, {
+          width: size,
+          margin: margin,
+          errorCorrectionLevel: correction,
+          color: {
+            dark: fgColor,
+            light: bgColor
+          }
+        });
+        latestDataURL = canvas.toDataURL('image/png');
+        downloadBtn.disabled = false;
+        const copySupported = 'clipboard' in navigator && 'write' in navigator.clipboard && 'ClipboardItem' in window;
+        copyBtn.disabled = !copySupported;
+        const charCount = value.length;
+        const safeSummary = summary ? escapeHTML(summary) : 'Custom data';
+        previewDetails.innerHTML = `<strong>${safeSummary}</strong><br>${charCount} characters • ${size}px • ${correctionLevels[correction]} error correction`;
+        showStatus('QR code updated successfully.', 'success');
+        previewFrame.style.background = bgColor;
+      } catch (error) {
+        console.error(error);
+        showStatus('Unable to generate QR code. Please adjust your settings and try again.', 'error');
+        downloadBtn.disabled = true;
+        copyBtn.disabled = true;
+        latestDataURL = '';
+      }
+    }
+
+    function downloadImage() {
+      if (!latestDataURL) return;
+      const link = document.createElement('a');
+      link.href = latestDataURL;
+      link.download = 'vectari-qr-code.png';
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      showStatus('PNG downloaded.', 'success');
+    }
+
+    async function copyImage() {
+      if (!latestDataURL || !navigator.clipboard?.write) return;
+      try {
+        const response = await fetch(latestDataURL);
+        const blob = await response.blob();
+        const item = new ClipboardItem({ 'image/png': blob });
+        await navigator.clipboard.write([item]);
+        showStatus('QR code copied to clipboard.', 'success');
+      } catch (error) {
+        console.error(error);
+        showStatus('Copy failed. Download instead.', 'error');
+      }
+    }
+
+    function attachHexListeners(colorInput, hexInput) {
+      colorInput.addEventListener('input', () => {
+        hexInput.value = colorInput.value.toUpperCase();
+        generateQRCode();
+      });
+      hexInput.addEventListener('blur', () => {
+        const parsed = parseHex(hexInput.value, colorInput.value);
+        hexInput.value = parsed;
+        colorInput.value = parsed;
+        generateQRCode();
+      });
+      hexInput.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter') {
+          event.preventDefault();
+          hexInput.blur();
+        }
+      });
+    }
+
+    form.addEventListener('submit', generateQRCode);
+    [sizeInput, marginInput, correctionInput].forEach((input) => {
+      input.addEventListener('change', generateQRCode);
+      input.addEventListener('input', () => {
+        showStatus('', 'info');
+      });
+    });
+
+    attachHexListeners(fgPicker, fgHex);
+    attachHexListeners(bgPicker, bgHex);
+
+    downloadBtn.addEventListener('click', downloadImage);
+    copyBtn.addEventListener('click', copyImage);
+
+    typeTabs.forEach((tab) => {
+      tab.addEventListener('click', () => setActiveType(tab.dataset.typeTab));
+      tab.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          setActiveType(tab.dataset.typeTab);
+        }
+        if (event.key === 'ArrowRight' || event.key === 'ArrowLeft') {
+          event.preventDefault();
+          const currentIndex = tabList.indexOf(tab);
+          const direction = event.key === 'ArrowRight' ? 1 : -1;
+          const newIndex = (currentIndex + direction + tabList.length) % tabList.length;
+          const nextTab = tabList[newIndex];
+          nextTab.focus();
+          setActiveType(nextTab.dataset.typeTab);
+        }
+      });
+    });
+
+    form.addEventListener('input', (event) => {
+      if (event.target.closest('.type-panels')) {
+        showStatus('', 'info');
+        generateQRCode();
+      }
+    });
+
+    document.getElementById('year').textContent = new Date().getFullYear();
+    syncHexInputs();
+    generateQRCode();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a tabbed QR code type selector with dedicated forms for URL, text, email, phone, SMS, Wi-Fi, and contact cards
- build validated payloads for each QR type and refresh the preview with accessible summaries
- wire up tab navigation, automatic regeneration, and clipboard/download status messaging

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dc58582170832895062203cd9088a5