### PR TITLE
Add Google Analytics tags to tools pages

### DIFF
--- a/tools/index.html
+++ b/tools/index.html
@@ -6,6 +6,14 @@
   <title>Vectari Tools | Useful Security Utilities</title>
   <meta name="description" content="Vectari tools provide helpful cybersecurity utilities including QR code generation and more coming soon.">
   <link rel="icon" type="image/png" href="/static/assets/logo.png">
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-4HFEY2Y8K7"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-4HFEY2Y8K7');
+  </script>
   <style>
     :root {
       --color-navy: #00172C;

--- a/tools/qr-generator/index.html
+++ b/tools/qr-generator/index.html
@@ -6,6 +6,14 @@
   <title>Vectari QR Code Generator | Create Custom QR Codes</title>
   <meta name="description" content="Generate high-quality QR codes for URLs, text, or contact information. Customize colors, size, error correction, and download ready-to-share images.">
   <link rel="icon" type="image/png" href="/static/assets/logo.png">
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-4HFEY2Y8K7"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-4HFEY2Y8K7');
+  </script>
   <style>
     :root {
       --color-navy: #00172C;


### PR DESCRIPTION
## Summary
- add the site Google Analytics snippet to the tools landing page
- add the same Google Analytics snippet to the QR generator tool page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd4ad6812c832892c0449b8591a007